### PR TITLE
[WIP] chatwindow ui done with css + mui

### DIFF
--- a/frontend/components/chat_window/BottomField.tsx
+++ b/frontend/components/chat_window/BottomField.tsx
@@ -1,0 +1,19 @@
+import SendButton from './SendButton'
+import TextField from './TextField'
+import './ChatWindow.css'
+import { useState } from 'react'
+
+const BottomField = () => {
+	const [msg, setMsg] = useState<string>('');
+
+	return (
+		<div className="bottom_field">
+			<TextField/>
+			<div>
+				<SendButton/>
+			</div>
+		</div>
+	)
+}
+
+export default BottomField;

--- a/frontend/components/chat_window/ChatField.tsx
+++ b/frontend/components/chat_window/ChatField.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react'
+import './ChatWindow.css'
+
+export interface IChat {
+	name: string;
+	message: string;
+}
+
+const mockMessageHistories:IChat[] = [
+		{
+			name: "jujeon",
+			message: "1 hello there",
+		},
+		{
+			name: "jujeon",
+			message: "2 dear bear",
+		},
+		{
+			name: "jujeon",
+			message: "3 I got there",
+		},
+		{
+			name: "jujeon",
+			message: "4 ft_transcendence asdkfjasdfklsadfijcj sdlkf l sdaif jisdf ljksdf ljk asd;kfadsk end",
+		},
+		{
+			name: "jujeon",
+			message: "5 ft_transcendence",
+		},
+		{
+			name: "jujeon",
+			message: "6 ft_transcendence",
+		},
+		{
+			name: "jujeon",
+			message: "7 ft_transcendence",
+		},
+		{
+			name: "jujeon",
+			message: "8 ft_transcendence",
+		},
+		{
+			name: "jujeon",
+			message: "9 ft_transcendence",
+		},
+		{
+			name: "jujeon",
+			message: "10 ft_transcendence",
+		},
+		{
+			name: "jujeon",
+			message: "11 ft_transcendence",
+		},
+		{
+			name: "jujeon",
+			message: "12 ende",
+		}
+]
+
+const ChatField = () => {
+	
+	const [msgHistories, setMsgHistories] = useState<IChat[]>([]);
+	
+	useEffect(()=> {
+		setMsgHistories(mockMessageHistories);
+	}, [])
+
+	return (
+		<div className="chat_field">
+				{msgHistories.map((value, i) => {
+					return (
+						<ul style={{margin: "1% 0% 1% 0%", padding:"2% 2% 0.5% 2%"}}>
+							<li className='message_box'>{value.name + ": " + value.message}</li>
+						</ul>	
+					)
+				})}
+			</div>
+	);
+}
+
+export default ChatField

--- a/frontend/components/chat_window/ChatWindow.css
+++ b/frontend/components/chat_window/ChatWindow.css
@@ -1,0 +1,107 @@
+.chat_window {
+	margin: 0;
+	padding: 0;
+	height: 55vh;
+	min-width: 300px;
+}
+
+/* room title field */
+
+.room_title_field {
+	background-color: #5290D3;
+	height: 5%;
+	border-radius: 5px;
+	margin: 2% 2% 4% 2%;
+
+	display: flex;
+	justify-content: space-between;
+	height: 44px;
+}
+
+.room_title_field_left {
+	display: flex;
+	align-items: center;
+}
+
+.stack_box {
+	margin: 2%;
+	margin-right: 2%;
+}
+.room_id {
+	vertical-align:middle;
+	color: #F2F070;
+	text-shadow: -1px 0px black, 0px 1px black, 1px 0px black, 0px -1px black;
+}
+
+.room_name {
+	font-size:x-large;
+	width: 40vw;
+	color: white;
+	text-shadow: 0px 0px 4px black;
+}
+.room_title_field_right {
+	align-items: center;
+	display: flex;
+	margin-top: 4.5px;
+}
+
+.room_type {
+}
+.room_setting {
+	margin-left: 10px;
+	margin-right: 7px;
+}
+
+/* chatting field */
+
+.chat_field {
+	background-color: #3272D2;
+	height: 83.5%;
+	border-radius: 5px;
+	list-style-type: none;
+	overflow-y: scroll;
+	margin: 0% 2% 4% 2%;
+}
+.message_box {
+	/* listStyleType:"none" */
+	list-style-type: none;
+	margin: 0px 0 0 0 ;
+	color: white;
+	padding: 0;
+}
+
+/* bottom field */
+
+.bottom_field {
+	background-color: #4174D3;
+	height: 11%;
+	/* width: 55vw; */
+	display: flex;
+	justify-content: center;
+	/* margin-top: 0.5%; */
+	/* margin-bottom: 2%; */
+	margin: 0.5% 2% 2% 2%;
+	border-radius: 5px;
+	min-width: 260px;
+}
+.input_field {
+	background-color: #1E4CA9;
+	height: 5%;
+	width: 40vw;
+	margin: 8px;
+	color: white;
+	margin-top: 2%;
+}
+.message_box {
+	/* listStyleType:"none" */
+	list-style-type: none;
+	margin-top: 0px;
+	color: white;
+}
+.send_button {
+	width: 13vw;
+	justify-content: center;
+	align-items: center;  
+	vertical-align:middle;
+	margin-top: 14%;
+}

--- a/frontend/components/chat_window/ChatWindow.tsx
+++ b/frontend/components/chat_window/ChatWindow.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import './ChatWindow.css'
+import BottomField from './BottomField'
+import ChatField from './ChatField'
+import RoomTitleField from './RoomTitleField'
+
+const ChatWindow = () => {
+
+	return (
+		<div className='chat_window'>
+			<RoomTitleField/>
+			<ChatField/>
+			<BottomField/>
+		</div>
+	)
+}
+
+export default ChatWindow

--- a/frontend/components/chat_window/RoomTitleField.tsx
+++ b/frontend/components/chat_window/RoomTitleField.tsx
@@ -1,0 +1,53 @@
+
+import Stack from './Stack'
+import Typography from '@mui/material/Typography'
+import VpnKeyTwoToneIcon from '@mui/icons-material/VpnKeyTwoTone';
+import SettingsIcon from '@mui/icons-material/Settings';
+import './ChatWindow.css'
+import IconButtons from './SettingIconButton'
+
+export interface IChatRoom {
+	roomName: string;
+	isProtected: boolean;
+}
+  
+const mockChatRoomList: IChatRoom[] = [
+	{
+		roomName: 'jujeon room',
+		isProtected: true,
+	},
+	{
+		roomName: 'silee room',
+		isProtected: false,
+	},
+	{
+		roomName: 'jeekim room',
+		isProtected: false,
+	},
+	{
+		roomName: 'hoslim room',
+		isProtected: true,
+	},
+];
+
+const RoomTitleField = () => {
+	
+	return (
+		<div className="room_title_field">
+			<div className='room_title_field_left'>
+				<Stack/>
+				<div className='room_name'>{mockChatRoomList[0].roomName}</div>
+			</div>
+			<div className='room_title_field_right'>
+				<div className='room_type'>
+					{mockChatRoomList[0].isProtected ? <VpnKeyTwoToneIcon/> : null}
+				</div>
+				<div className='room_setting'>
+					<IconButtons/>
+				</div>
+			</div>
+		</div>
+	)
+}
+
+export default RoomTitleField;

--- a/frontend/components/chat_window/SendButton.tsx
+++ b/frontend/components/chat_window/SendButton.tsx
@@ -1,0 +1,15 @@
+
+import { Button } from "@mui/material";
+import SendIcon from '@mui/icons-material/Send';
+import './ChatWindow.css'
+
+const SendButton = () => {
+	
+	return (
+		<Button className='send_button' variant="contained" endIcon={<SendIcon />}>
+		Send
+		</Button>
+	)
+}
+
+export default SendButton

--- a/frontend/components/chat_window/SettingIconButton.tsx
+++ b/frontend/components/chat_window/SettingIconButton.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AlarmIcon from '@mui/icons-material/Alarm';
+import AddShoppingCartIcon from '@mui/icons-material/AddShoppingCart';
+import SettingsIcon from '@mui/icons-material/Settings';
+
+
+export default function IconButtons() {
+  return (
+    <Stack direction="row" spacing={1} >
+      <IconButton color="primary" aria-label="setting">
+	  	<SettingsIcon/>
+      </IconButton>
+    </Stack>
+  );
+}

--- a/frontend/components/chat_window/Stack.tsx
+++ b/frontend/components/chat_window/Stack.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+ 
+import { styled } from '@mui/material/styles';
+import Typography from '@mui/material/Typography'
+import './ChatWindow.css'
+
+const Item = styled(Paper)(({ theme }) => ({
+  backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
+  ...theme.typography.body2,
+  padding: theme.spacing(1),
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+  
+}));
+
+export default function DirectionStack() {
+  return (
+    <div className='stack_box'>
+      <Stack direction="row" style={{height:"80%"}} spacing={2} >
+        <Item className='room_id' style={{alignItems:"center"}}>
+			002
+		 </Item>
+      </Stack>
+    </div>
+  );
+}

--- a/frontend/components/chat_window/TextField.tsx
+++ b/frontend/components/chat_window/TextField.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import FormControl, { useFormControl } from '@mui/material/FormControl';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import Box from '@mui/material/Box';
+import FormHelperText from '@mui/material/FormHelperText';
+import { useState } from 'react';
+
+export default function UseFormControl() {
+  const [msg, setMsg] = useState<string>('');
+
+  const changeMsg = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setMsg(event.target.value);
+  }
+
+  return (
+    <Box component="form" noValidate autoComplete="off">
+      <FormControl>
+        <OutlinedInput className="input_field" onChange={changeMsg} placeholder="Please enter message" />
+      </FormControl>
+    </Box>
+  );
+}

--- a/frontend/components/public/Layout.tsx
+++ b/frontend/components/public/Layout.tsx
@@ -7,6 +7,7 @@ import ModalBasic from "../main/myprofile/ModalBasic";
 import Modal from "../main/myprofile/Modal";
 import Myprofile from "../main/myprofile/MyProfile";
 import RoomList from "../main/room_list/RoomList";
+import ChatWindow from "../chat_window/ChatWindow";
 
 const Layout = () => {
   return (
@@ -31,7 +32,7 @@ const Layout = () => {
         sx={{
           width: "60vw",
           height: "100vh",
-          backgroundColor: "green",
+          backgroundColor: "#6EC2F5",
           padding: 0,
           margin: 0,
         }}
@@ -40,8 +41,7 @@ const Layout = () => {
           game start
           <GameStartButton />
         </CardContent>
-
-        <CardContent>chatting window</CardContent>
+        <ChatWindow/>
       </Stack>
 
       <Stack


### PR DESCRIPTION
한 일 :
- css 와 mui를 혼용해 컴포넌트 구현완료

해야할 일 (알고보니 이건 기능명세코드가 추가되고 거기서 작업을 해야하는 부분) : 
- mui 컴포넌트로 전부 변환예정
- 지금은 버튼컴포넌트와 input 컴포넌트가 같은 컴포넌트에 있지않고 형제관계로 되어있음. 백엔드 서버에서 소켓이 준비가 될테니까 챗윈도우에서도 메세지를 보낼 수 있게 작업해두어야함.
- 지킴님의 대화방 목록과 연계하여 다른방을 누르면 챗윈도우에서다르방으로 전환되는 걸 구현해야함.
- 백엔드에서 dm api가 완성되면 혹은 mock server 를 활용하여 dm 방에 미리 저장된 대화내역을 불러오는 기능을 구현해야함.