### PR TITLE
75 main chat 05 api 멤버 우클릭시 드롭다운인 set/unset admin, kick, ban, mute ap

### DIFF
--- a/frontend/app/game/page.tsx
+++ b/frontend/app/game/page.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
 } from "@mui/material";
 
-import { main } from "@/components/public/Layout";
+import { main } from "@/type/type";
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";

--- a/frontend/app/gameplaying/page.tsx
+++ b/frontend/app/gameplaying/page.tsx
@@ -12,7 +12,7 @@ import {
 } from "@mui/material";
 
 import { useRouter } from "next/navigation";
-import { main } from "@/components/public/Layout";
+import { main } from "@/type/type";
 import { useEffect, useState } from "react";
 import PingPong from "@/components/game/ingame/PingPong";
 import { resetGameContextData, useGame } from "@/context/GameContext";

--- a/frontend/app/gameresult/page.tsx
+++ b/frontend/app/gameresult/page.tsx
@@ -16,7 +16,7 @@ const font = createTheme({
   },
 });
 import { useRouter } from "next/navigation";
-import { main } from "@/components/public/Layout";
+import { main } from "@/type/type";
 import { useGame } from "@/context/GameContext";
 import { useEffect } from "react";
 import { resetGameContextData } from "@/context/GameContext";

--- a/frontend/app/inwaiting/page.tsx
+++ b/frontend/app/inwaiting/page.tsx
@@ -26,7 +26,7 @@ const modalStyle = {
 };
 
 import { useRouter } from "next/navigation";
-import { main } from "@/components/public/Layout";
+import { main } from "@/type/type";
 import { useGame } from "@/context/GameContext";
 
 const inwaiting = () => {

--- a/frontend/app/login/auth/page.tsx
+++ b/frontend/app/login/auth/page.tsx
@@ -4,6 +4,7 @@ import { Box, Card, CircularProgress, Typography } from "@mui/material";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 import { main } from "@/font/color";
+import { useUser } from "@/context/UserContext";
 
 const modalStyle = {
   position: "absolute" as "absolute",
@@ -20,6 +21,7 @@ const modalStyle = {
 const Auth = () => {
   const searchParam = useSearchParams();
   const router = useRouter();
+  const { userState, userDispatch } = useUser();
 
   interface Data {
     token: string;
@@ -50,9 +52,7 @@ const Auth = () => {
           console.log(data);
           localStorage.setItem("authorization", data.token); // 서버에서 받은 토큰을 저장
           localStorage.setItem("token", data.jwt);
-          localStorage.setItem("img", data.user.imgUri);
-          localStorage.setItem("intra", data.user.intra);
-          localStorage.setItem("idx", data.user.userIdx.toString());
+          userDispatch({ type: "CHANGE_NICK_NAME", value: data.user.intra });
           return router.push(`/`);
         }
       })

--- a/frontend/app/login/auth/page.tsx
+++ b/frontend/app/login/auth/page.tsx
@@ -50,6 +50,9 @@ const Auth = () => {
           console.log(data);
           localStorage.setItem("authorization", data.token); // 서버에서 받은 토큰을 저장
           localStorage.setItem("token", data.jwt);
+          localStorage.setItem("img", data.user.imgUri);
+          localStorage.setItem("intra", data.user.intra);
+          localStorage.setItem("idx", data.user.userIdx.toString());
           return router.push(`/`);
         }
       })

--- a/frontend/app/login/auth/page.tsx
+++ b/frontend/app/login/auth/page.tsx
@@ -21,7 +21,7 @@ const modalStyle = {
 const Auth = () => {
   const searchParam = useSearchParams();
   const router = useRouter();
-  const { userState, userDispatch } = useUser();
+  const { userDispatch } = useUser();
 
   interface Data {
     token: string;
@@ -49,10 +49,10 @@ const Auth = () => {
         if (res.status === 200) {
           localStorage.setItem("loggedIn", "true");
           const data: Data = await res.json();
-          console.log(data);
           localStorage.setItem("authorization", data.token); // 서버에서 받은 토큰을 저장
           localStorage.setItem("token", data.jwt);
-          userDispatch({ type: "CHANGE_NICK_NAME", value: data.user.intra });
+          localStorage.setItem("intra", data.user.intra);
+          localStorage.setItem("idx", data.user.userIdx.toString());
           return router.push(`/`);
         }
       })

--- a/frontend/app/mypage/page.tsx
+++ b/frontend/app/mypage/page.tsx
@@ -49,7 +49,7 @@ const myProfileStyle = {
 
 import { useRouter, useSearchParams } from "next/navigation";
 
-import { main } from "@/components/public/Layout";
+import { main } from "@/type/type";
 import { useState } from "react";
 import { get } from "https";
 import MyGameLog from "@/components/main/myprofile/MyGameLog";

--- a/frontend/app/optionselect/page.tsx
+++ b/frontend/app/optionselect/page.tsx
@@ -13,7 +13,7 @@ import {
 import React from "react";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { main } from "@/components/public/Layout";
+import { main } from "@/type/type";
 import { useGame } from "@/context/GameContext";
 
 type SpeedOption = "speed1" | "speed2" | "speed3";

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,7 +4,8 @@ import Layout from "@/components/public/Layout";
 import { useEffect } from "react";
 import { io } from "socket.io-client";
 
-const userId = 98364;
+// const userId = 98364;
+const userId = localStorage.getItem("idx");
 // export const socket = io("http://localhost:4000/chat");
 export const socket = io("http://localhost:4000/chat", {
   query: { userId: userId },

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,7 +4,8 @@ import Layout from "@/components/public/Layout";
 import { useEffect } from "react";
 import { io } from "socket.io-client";
 
-const userId = localStorage.getItem("idx");
+const userId = 98364;
+// const userId = localStorage.getItem("idx");
 // export const socket = io("http://localhost:4000/chat");
 export const socket = io("http://localhost:4000/chat", {
   query: { userId: userId },

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,7 +4,7 @@ import Layout from "@/components/public/Layout";
 import { useEffect } from "react";
 import { io } from "socket.io-client";
 
-const userId = 3;
+const userId = 98364;
 // export const socket = io("http://localhost:4000/chat");
 export const socket = io("http://localhost:4000/chat", {
   query: { userId: userId },

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,7 +4,6 @@ import Layout from "@/components/public/Layout";
 import { useEffect } from "react";
 import { io } from "socket.io-client";
 
-// const userId = 98364;
 const userId = localStorage.getItem("idx");
 // export const socket = io("http://localhost:4000/chat");
 export const socket = io("http://localhost:4000/chat", {

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import Layout from "@/components/public/Layout";
-import { useEffect } from "react";
 import { io } from "socket.io-client";
 
-const userId = typeof window !== 'undefined' ? localStorage.getItem("idx") : null;
-// const userId = localStorage.getItem("idx");
+const userId =
+  typeof window !== "undefined" ? localStorage.getItem("idx") : null;
 export const socket = io("http://localhost:4000/chat", {
   query: { userId: userId },
 });

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,9 +4,8 @@ import Layout from "@/components/public/Layout";
 import { useEffect } from "react";
 import { io } from "socket.io-client";
 
-const userId = 98364;
+const userId = typeof window !== 'undefined' ? localStorage.getItem("idx") : null;
 // const userId = localStorage.getItem("idx");
-// export const socket = io("http://localhost:4000/chat");
 export const socket = io("http://localhost:4000/chat", {
   query: { userId: userId },
 });

--- a/frontend/components/main/InviteGame/InviteGame.tsx
+++ b/frontend/components/main/InviteGame/InviteGame.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { Box, Button, Card, CardContent, Modal } from "@mui/material";
 import { useState } from "react";
-import { main } from "@/components/public/Layout";
+import { main } from "@/type/type";
 import { useRouter } from "next/navigation";
 
 const modalStyle = {

--- a/frontend/components/main/InviteGame/WaitAccept.tsx
+++ b/frontend/components/main/InviteGame/WaitAccept.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { Box, Button, Card, CardContent, Modal } from "@mui/material";
 import { useState } from "react";
-import { main } from "@/components/public/Layout";
+import { main } from "@/type/type";
 import { useRouter } from "next/navigation";
 
 const modalStyle = {

--- a/frontend/components/main/chat_window/BottomField/BottomField.tsx
+++ b/frontend/components/main/chat_window/BottomField/BottomField.tsx
@@ -53,7 +53,7 @@ const BottomField = ({ setMsgs }: Props) => {
       event.preventDefault();
       const payload = {
         channelIdx: roomState.currentRoom?.channelIdx,
-        senderIdx: 3,
+        senderIdx: 98364,
         msg: msg,
       };
       console.log("payload", payload);

--- a/frontend/components/main/friend_list/Friend.tsx
+++ b/frontend/components/main/friend_list/Friend.tsx
@@ -11,16 +11,6 @@ const loginOff = (
   <Image src="/logoff.png" alt="offline" width={10} height={10} />
 );
 
-interface IFriend {
-  friendNickname: string;
-  isOnline: boolean;
-}
-
-interface IBlock {
-  targetNickname: string;
-  targetIdx: number;
-}
-
 interface IUserProp {
   friendNickname: string;
   isOnline: boolean;

--- a/frontend/components/main/member_list/Member.tsx
+++ b/frontend/components/main/member_list/Member.tsx
@@ -219,10 +219,10 @@ export default function Member({
         </div>
         <div className="memname">{person.nickname}</div>
         <div className="memicon">
-          {/* {person.permission === Permission.OWNER ? (
-              <StarRoundedIcon sx={{ height: "15px", color: "yellow" }} />
-            ) : null}
-            {person.permission === Permission.ADMIN ? (
+          {person.permission === Permission.OWNER ? (
+            <StarRoundedIcon sx={{ height: "15px", color: "yellow" }} />
+          ) : null}
+          {/* {person.permission === Permission.ADMIN ? (
               <StarOutlineRoundedIcon
                 sx={{ height: "15px", color: "yellow" }}
               />

--- a/frontend/components/main/member_list/Member.tsx
+++ b/frontend/components/main/member_list/Member.tsx
@@ -32,7 +32,7 @@ export default function Member({
   const [string, setString] = useState<string>("");
   const [isAdmin, setIsAdmin] = useState(false);
   const [adminAry, setAdminAry] = useState<string[]>([]);
-  const [authorization, setAuthorization] = useState("");
+  // const [authorization, setAuthorization] = useState("");
   const { roomState, roomDispatch } = useRoom();
   const { userState } = useUser();
   const strings = [
@@ -47,29 +47,29 @@ export default function Member({
     setOpenModal(true);
   };
 
-  useEffect(() => {
-    const CheckGrant = (json: string) => {
-      setAuthorization(json);
-    };
-    socket.on("chat_get_grant", CheckGrant);
+  // useEffect(() => {
+  //   const CheckGrant = (json: string) => {
+  //     setAuthorization(json);
+  //   };
+  //   socket.on("chat_get_grant", CheckGrant);
 
-    return () => {
-      socket.off("chat_get_grant", CheckGrant);
-    };
-  }, []);
+  //   return () => {
+  //     socket.off("chat_get_grant", CheckGrant);
+  //   };
+  // }, []);
 
   const handleOpenMenu = (
     e: MouseEvent<HTMLDivElement, globalThis.MouseEvent>
   ) => {
     e.preventDefault();
-    socket.emit(
-      "chat_get_grant",
-      JSON.stringify({
-        userIdx: userState.userIdx,
-        channelIdx: roomState.currentRoom?.channelIdx,
-      }),
-      () => {}
-    );
+    // socket.emit(
+    //   "chat_get_grant",
+    //   JSON.stringify({
+    //     userIdx: userState.userIdx,
+    //     channelIdx: roomState.currentRoom?.channelIdx,
+    //   }),
+    //   () => {}
+    // );
     setAnchorEl(e.currentTarget);
   };
 

--- a/frontend/components/main/member_list/Member.tsx
+++ b/frontend/components/main/member_list/Member.tsx
@@ -11,6 +11,7 @@ import {
   IChatKick,
   IChatRoomAdmin,
   IMember,
+  Mode,
   Permission,
   alert,
 } from "@/type/type";
@@ -32,7 +33,7 @@ export default function Member({
   const [string, setString] = useState<string>("");
   const [isAdmin, setIsAdmin] = useState(false);
   const [adminAry, setAdminAry] = useState<string[]>([]);
-  // const [authorization, setAuthorization] = useState("");
+  const [isGranted, setIsGranted] = useState<boolean>(false);
   const { roomState, roomDispatch } = useRoom();
   const { userState } = useUser();
   const strings = [
@@ -47,29 +48,41 @@ export default function Member({
     setOpenModal(true);
   };
 
-  // useEffect(() => {
-  //   const CheckGrant = (json: string) => {
-  //     setAuthorization(json);
-  //   };
-  //   socket.on("chat_get_grant", CheckGrant);
+  useEffect(() => {
+    const CheckGrant = (json: Permission) => {
+      // setAuthorization(json);
+      json === Permission.MEMBER ? setIsGranted(false) : setIsGranted(true);
+    };
+    socket.on("chat_get_grant", CheckGrant);
 
-  //   return () => {
-  //     socket.off("chat_get_grant", CheckGrant);
-  //   };
-  // }, []);
+    return () => {
+      socket.off("chat_get_grant", CheckGrant);
+    };
+  }, []);
 
   const handleOpenMenu = (
     e: MouseEvent<HTMLDivElement, globalThis.MouseEvent>
   ) => {
     e.preventDefault();
+    console.log("handleOpenMenu");
     // socket.emit(
     //   "chat_get_grant",
     //   JSON.stringify({
     //     userIdx: userState.userIdx,
-    //     channelIdx: roomState.currentRoom?.channelIdx,
+    //     channelIdx: roomState.currentRoom!.channelIdx,
     //   }),
-    //   () => {}
+    //   (ret: any) => {
+    //     console.log("handleOpenMenu ret : ", ret);
+    //   }
     // );
+
+    // ||
+    // adminAry.map((admin) => {
+    //   console.log("admin === person.nickname", admin, person.nickname);
+    //   return admin === person.nickname ? true : false;
+    // })
+
+    // isGranted ? setAnchorEl(e.currentTarget) : null;
     setAnchorEl(e.currentTarget);
   };
 
@@ -119,16 +132,17 @@ export default function Member({
     isAdmin ? setString(strings[0]) : setString(strings[1]);
   }, [isAdmin]);
 
-  // useEffect(() => {
-  //   const ChatMute = (data: any) => { // 아직 api 완성안됨
-  //     console.log("Mute : ", data);
-  //   };
-  //   socket.on("chat_mute", ChatMute);
+  useEffect(() => {
+    const ChatMute = (data: any) => {
+      // 아직 api 완성안됨
+      console.log("Mute : ", data);
+    };
+    socket.on("chat_mute", ChatMute);
 
-  //   return () => {
-  //     socket.off("chat_mute", ChatMute);
-  //   };
-  // });
+    return () => {
+      socket.off("chat_mute", ChatMute);
+    };
+  });
 
   const Mute = () => {
     socket.emit(
@@ -215,12 +229,33 @@ export default function Member({
         className="membtn"
         onClick={handleOpenModal}
         onContextMenu={
-          (e) => handleOpenMenu(e)
-          // (e) =>
-          //   userState.nickname !== person.nickname &&
-          //   authorization === (Permission.ADMIN || Permission.OWNER)
-          //     ? handleOpenMenu(e)
-          //     : e.preventDefault()
+          // (e) => handleOpenMenu(e)
+          (e) => {
+            //owner일때
+            //admin일때
+            //mem일때
+            // console.log("here");
+            // socket.emit(
+            //   "chat_get_grant",
+            //   JSON.stringify({
+            //     userIdx: userState.userIdx,
+            //     channelIdx: roomState.currentRoom!.channelIdx,
+            //   }),
+            //   (ret: any) => {
+            //     console.log("handleOpenMenu ret : ", ret);
+            //   }
+            // );
+            console.log(
+              "userState.nickname === roomState.currentRoom!.owner",
+              userState.nickname,
+              roomState.currentRoom!.owner
+            );
+            userState.nickname !== person.nickname &&
+            userState.nickname === roomState.currentRoom!.owner
+              ? // authorization === (Permission.ADMIN || Permission.OWNER)
+                handleOpenMenu(e)
+              : e.preventDefault();
+          }
         }
       >
         <div className="memimg">

--- a/frontend/components/main/member_list/Member.tsx
+++ b/frontend/components/main/member_list/Member.tsx
@@ -208,7 +208,7 @@ export default function Member({
         onClick={handleOpenModal}
         onContextMenu={
           (e) => handleOpenMenu(e)
-          // authorization === (Permission.ADMIN || Permission.OWNER)
+          // (authorization === (Permission.ADMIN || Permission.OWNER)) && (userState.nickname !== person.nickname)
           //   ? handleOpenMenu(e)
           //   : e.preventDefault()
         }
@@ -219,9 +219,6 @@ export default function Member({
         </div>
         <div className="memname">{person.nickname}</div>
         <div className="memicon">
-          {/* {person.permission === Permission.OWNER ? (
-            <StarRoundedIcon sx={{ height: "15px", color: "yellow" }} />
-          ) : null} */}
           {person.nickname === roomState.currentRoom?.owner ? (
             <StarRoundedIcon sx={{ height: "15px", color: "yellow" }} />
           ) : null}

--- a/frontend/components/main/member_list/Member.tsx
+++ b/frontend/components/main/member_list/Member.tsx
@@ -102,7 +102,8 @@ export default function Member({
 
   useEffect(() => {
     const ChatRoomAdmin = (json: IChatRoomAdmin) => {
-      setAdminAry(json.admin);
+      roomDispatch({type : "SET_ADMIN_ARY", value : json.admin});
+      // setAdminAry(json.admin);
     };
     socket.on("chat_room_admin", ChatRoomAdmin);
 
@@ -264,7 +265,10 @@ export default function Member({
         </div>
         <div className="memname">{person.nickname}</div>
         <div className="memicon">
-          {adminAry.map((admin) => {
+          {
+            // adminAry.map((admin) => {
+            roomState.adminAry.map((admin) => {
+            console.log("admin :", admin);
             return admin === person.nickname ? (
               <StarOutlineRoundedIcon
                 sx={{ height: "15px", color: "yellow" }}
@@ -275,10 +279,8 @@ export default function Member({
             <StarRoundedIcon sx={{ height: "15px", color: "yellow" }} />
           ) : null}
           {/* {person.permission === Permission.ADMIN ? (
-                <StarOutlineRoundedIcon
-                  sx={{ height: "15px", color: "yellow" }}
-                />
-              ) : null} */}
+            <StarOutlineRoundedIcon sx={{ height: "15px", color: "yellow" }} />
+          ) : null} */}
         </div>
       </div>
       <Menu

--- a/frontend/components/main/member_list/Member.tsx
+++ b/frontend/components/main/member_list/Member.tsx
@@ -6,14 +6,14 @@ import StarOutlineRoundedIcon from "@mui/icons-material/StarOutlineRounded";
 import "@/components/main/member_list/MemberList.css";
 import { useState, MouseEvent, useEffect } from "react";
 import MemberModal from "./MemberModal";
+import { useRoom } from "@/context/RoomContext";
 import {
   IChatKick,
   IChatRoomAdmin,
   IMember,
   Permission,
   alert,
-  useRoom,
-} from "@/context/RoomContext";
+} from "@/type/type";
 import { Menu, MenuItem } from "@mui/material";
 import { useUser } from "@/context/UserContext";
 import Alert from "@mui/material/Alert";

--- a/frontend/components/main/member_list/Member.tsx
+++ b/frontend/components/main/member_list/Member.tsx
@@ -9,6 +9,7 @@ import MemberModal from "./MemberModal";
 import { useRoom } from "@/context/RoomContext";
 import {
   IChatKick,
+  IChatMute,
   IChatRoomAdmin,
   IMember,
   Mode,
@@ -134,9 +135,11 @@ export default function Member({
   }, [isAdmin]);
 
   useEffect(() => {
-    const ChatMute = (data: any) => {
-      // 아직 api 완성안됨
+    const ChatMute = (data: IChatMute) => {
       console.log("Mute : ", data);
+      // console로 값 확인 후 아래
+      // emit - roomId 채팅에 있던 사람들한테 알림 쏴주기
+      // TODO : mute된 사람 전역? / useState
     };
     socket.on("chat_mute", ChatMute);
 

--- a/frontend/components/main/member_list/Member.tsx
+++ b/frontend/components/main/member_list/Member.tsx
@@ -103,7 +103,7 @@ export default function Member({
 
   useEffect(() => {
     const ChatRoomAdmin = (json: IChatRoomAdmin) => {
-      roomDispatch({type : "SET_ADMIN_ARY", value : json.admin});
+      // roomDispatch({ type: "SET_ADMIN_ARY", value: json.admin });
       // setAdminAry(json.admin);
     };
     socket.on("chat_room_admin", ChatRoomAdmin);
@@ -268,19 +268,30 @@ export default function Member({
         </div>
         <div className="memname">{person.nickname}</div>
         <div className="memicon">
-          {
-            // adminAry.map((admin) => {
-            roomState.adminAry.map((admin) => {
-            console.log("admin :", admin);
-            return admin === person.nickname ? (
-              <StarOutlineRoundedIcon
-                sx={{ height: "15px", color: "yellow" }}
-              />
-            ) : null;
-          })}
           {person.nickname === roomState.currentRoom?.owner ? (
             <StarRoundedIcon sx={{ height: "15px", color: "yellow" }} />
+          ) : (
+            roomState.adminAry.map((admin) => {
+              return admin.nickname === person.nickname ? (
+                <StarOutlineRoundedIcon
+                  sx={{ height: "15px", color: "yellow" }}
+                />
+              ) : null;
+            })
+          )}
+          {/* {person.nickname === roomState.currentRoom?.owner ? (
+            <StarRoundedIcon sx={{ height: "15px", color: "yellow" }} />
           ) : null}
+          {
+            roomState.adminAry.map((admin) => {
+              console.log("StarOutlineRoundedIcon admin :", admin);
+              return admin.nickname === person.nickname ? (
+                <StarOutlineRoundedIcon
+                  sx={{ height: "15px", color: "yellow" }}
+                />
+              ) : null;
+            })
+          } */}
           {/* {person.permission === Permission.ADMIN ? (
             <StarOutlineRoundedIcon sx={{ height: "15px", color: "yellow" }} />
           ) : null} */}

--- a/frontend/components/main/member_list/Member.tsx
+++ b/frontend/components/main/member_list/Member.tsx
@@ -219,7 +219,10 @@ export default function Member({
         </div>
         <div className="memname">{person.nickname}</div>
         <div className="memicon">
-          {person.permission === Permission.OWNER ? (
+          {/* {person.permission === Permission.OWNER ? (
+            <StarRoundedIcon sx={{ height: "15px", color: "yellow" }} />
+          ) : null} */}
+          {person.nickname === roomState.currentRoom?.owner ? (
             <StarRoundedIcon sx={{ height: "15px", color: "yellow" }} />
           ) : null}
           {/* {person.permission === Permission.ADMIN ? (

--- a/frontend/components/main/member_list/Member.tsx
+++ b/frontend/components/main/member_list/Member.tsx
@@ -139,6 +139,7 @@ export default function Member({
     const ChatKick = (data: IChatKick) => {
       setShowAlert(true);
       setString(strings[3]);
+      roomDispatch({ type: "SET_CUR_MEM", value: data.leftMember });
     };
     socket.on("chat_kick", ChatKick);
 
@@ -168,8 +169,33 @@ export default function Member({
     // }
   };
 
+  useEffect(() => {
+    const ChatBan = (data: IChatKick) => {
+      console.log("ChatBan : ", data);
+      setShowAlert(true);
+      setString(strings[3]);
+      roomDispatch({ type: "SET_CUR_MEM", value: data.leftMember });
+    };
+    socket.on("chat_kick", ChatBan);
+
+    return () => {
+      socket.off("chat_kick", ChatBan);
+    };
+  }, []);
+
   const Ban = () => {
-    // socket.emit("chat_ban");
+    socket.emit(
+      "chat_ban",
+      JSON.stringify({
+        channelIdx: roomState.currentRoom?.channelIdx,
+        targetNickname: userState.nickname,
+        targetIdx: userState.userIdx,
+      }),
+      (statusCode: any) => {
+        // 아직 안정해짐
+        console.log("Ban : ", statusCode);
+      }
+    );
     setShowAlert(true);
     setString(strings[4]);
   };
@@ -180,10 +206,11 @@ export default function Member({
         key={idx}
         className="membtn"
         onClick={handleOpenModal}
-        onContextMenu={(e) =>
-          authorization === (Permission.ADMIN || Permission.OWNER)
-            ? handleOpenMenu(e)
-            : e.preventDefault()
+        onContextMenu={
+          (e) => handleOpenMenu(e)
+          // authorization === (Permission.ADMIN || Permission.OWNER)
+          //   ? handleOpenMenu(e)
+          //   : e.preventDefault()
         }
       >
         <div className="memimg">

--- a/frontend/components/main/member_list/MemberList.tsx
+++ b/frontend/components/main/member_list/MemberList.tsx
@@ -6,7 +6,7 @@ import Title from "../room_list/Title";
 import Members from "./Members";
 import { useRoom } from "@/context/RoomContext";
 
-export default function MemberList({}: {}) {
+export default function MemberList() {
   const { roomState } = useRoom();
 
   return (

--- a/frontend/components/main/member_list/MemberModal.tsx
+++ b/frontend/components/main/member_list/MemberModal.tsx
@@ -14,7 +14,7 @@ import {
 import Image from "next/image";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import { IFriend } from "../friend_list/FriendList";
-import { IMember } from "@/context/RoomContext";
+import { IMember } from "@/type/type";
 import { useFriend } from "@/context/FriendContext";
 
 const modalStyle = {

--- a/frontend/components/main/member_list/Members.tsx
+++ b/frontend/components/main/member_list/Members.tsx
@@ -2,7 +2,8 @@
 
 import Member from "./Member";
 import "@/components/main/member_list/MemberList.css";
-import { IMember, Mode, useRoom } from "@/context/RoomContext";
+import { useRoom } from "@/context/RoomContext";
+import { IMember, Mode } from "@/type/type";
 import { useUser } from "@/context/UserContext";
 import { useEffect, useState } from "react";
 

--- a/frontend/components/main/myprofile/MyGameLog.tsx
+++ b/frontend/components/main/myprofile/MyGameLog.tsx
@@ -6,7 +6,7 @@ import { Card } from "@mui/material";
 import axios from "axios";
 import { useEffect, useState, useRef, useCallback } from "react";
 
-import { main } from "@/components/public/Layout";
+import { main } from "@/type/type";
 const TOTAL_PAGES = 100;
 
 const options = {

--- a/frontend/components/main/room_list/CreateRoomModal.tsx
+++ b/frontend/components/main/room_list/CreateRoomModal.tsx
@@ -41,17 +41,6 @@ export default function CreateRoomModal({
   useEffect(() => {
     const ChatCreateRoom = (data: IChatRoom) => {
       roomDispatch({ type: "ADD_ROOM", value: data });
-      // roomDispatch({
-      //   type: "SET_CUR_MEM",
-      //   value: [
-      //     {
-      //       userIdx: userState.userIdx,
-      //       nickname: userState.nickname,
-      //       imgUri: userState.imgUri,
-      //       permission: Permission.OWNER,
-      //     },
-      //   ],
-      // });
       setValue("");
       setOpen(false);
     };
@@ -61,16 +50,15 @@ export default function CreateRoomModal({
       socket.off("BR_chat_create_room", ChatCreateRoom);
     };
   }, []);
-  //userId=?
 
   const OnClick = () => {
     socket.emit(
       "BR_chat_create_room",
       JSON.stringify({ password: value }),
-      (res: any) => {} // 아직 안정해짐
+      (ret: number) => {
+        // if (ret === 200)
+      }
     );
-    //TODO : dto 정하는게 어떨까... < 추천
-    // 일단은 이렇게. dto는 나중에
   };
 
   return (

--- a/frontend/components/main/room_list/CreateRoomModal.tsx
+++ b/frontend/components/main/room_list/CreateRoomModal.tsx
@@ -40,18 +40,17 @@ export default function CreateRoomModal({
   useEffect(() => {
     const ChatCreateRoom = (data: IChatRoom) => {
       roomDispatch({ type: "ADD_ROOM", value: data });
-      //생성한 방에 들어가는 로직?
-      roomDispatch({
-        type: "SET_CUR_MEM",
-        value: [
-          {
-            userIdx: userState.userIdx,
-            nickname: userState.nickname,
-            imgUri: userState.imgUri,
-            permission: Permission.OWNER,
-          },
-        ],
-      });
+      // roomDispatch({
+      //   type: "SET_CUR_MEM",
+      //   value: [
+      //     {
+      //       userIdx: userState.userIdx,
+      //       nickname: userState.nickname,
+      //       imgUri: userState.imgUri,
+      //       permission: Permission.OWNER,
+      //     },
+      //   ],
+      // });
       setValue("");
       setOpen(false);
     };

--- a/frontend/components/main/room_list/CreateRoomModal.tsx
+++ b/frontend/components/main/room_list/CreateRoomModal.tsx
@@ -4,7 +4,7 @@ import { useState, Dispatch, SetStateAction, useEffect } from "react";
 import { Box, Button, Card, Stack, TextField, Typography } from "@mui/material";
 import "@/components/main/room_list/RoomList.css";
 import Modal from "@mui/material/Modal";
-import { IChatRoom, useRoom } from "@/context/RoomContext";
+import { IChatRoom, Permission, useRoom } from "@/context/RoomContext";
 import { socket } from "@/app/page";
 import { useUser } from "@/context/UserContext";
 
@@ -40,6 +40,17 @@ export default function CreateRoomModal({
   useEffect(() => {
     const ChatCreateRoom = (data: IChatRoom) => {
       roomDispatch({ type: "ADD_ROOM", value: data });
+      roomDispatch({
+        type: "SET_CUR_MEM",
+        value: [
+          {
+            userIdx: userState.userIdx,
+            nickname: userState.nickname,
+            imgUri: userState.imgUri,
+            permission: Permission.OWNER,
+          },
+        ],
+      });
       setValue("");
       setOpen(false);
     };

--- a/frontend/components/main/room_list/CreateRoomModal.tsx
+++ b/frontend/components/main/room_list/CreateRoomModal.tsx
@@ -4,7 +4,8 @@ import { useState, Dispatch, SetStateAction, useEffect } from "react";
 import { Box, Button, Card, Stack, TextField, Typography } from "@mui/material";
 import "@/components/main/room_list/RoomList.css";
 import Modal from "@mui/material/Modal";
-import { IChatRoom, Permission, useRoom } from "@/context/RoomContext";
+import { useRoom } from "@/context/RoomContext";
+import { IChatRoom, Permission } from "@/type/type";
 import { socket } from "@/app/page";
 import { useUser } from "@/context/UserContext";
 

--- a/frontend/components/main/room_list/CreateRoomModal.tsx
+++ b/frontend/components/main/room_list/CreateRoomModal.tsx
@@ -40,6 +40,7 @@ export default function CreateRoomModal({
   useEffect(() => {
     const ChatCreateRoom = (data: IChatRoom) => {
       roomDispatch({ type: "ADD_ROOM", value: data });
+      //생성한 방에 들어가는 로직?
       roomDispatch({
         type: "SET_CUR_MEM",
         value: [

--- a/frontend/components/main/room_list/ProtectedModal.tsx
+++ b/frontend/components/main/room_list/ProtectedModal.tsx
@@ -15,6 +15,7 @@ import LockRoundedIcon from "@mui/icons-material/LockRounded";
 import { useRoom } from "@/context/RoomContext";
 import { IChatRoom } from "@/context/RoomContext";
 import { socket } from "@/app/page";
+import { useUser } from "@/context/UserContext";
 
 const box = {
   position: "absolute" as "absolute",
@@ -53,6 +54,7 @@ export default function ProtectedModal({
   fail: boolean;
 }) {
   const { roomDispatch } = useRoom();
+  const { userState } = useUser();
   const pwRef = useRef("");
 
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -65,8 +67,8 @@ export default function ProtectedModal({
     socket.emit(
       "chat_enter",
       JSON.stringify({
-        userNickname: "hoslim",
-        userIdx: 3,
+        userNickname: userState.nickname,
+        userIdx: userState.userIdx,
         channelIdx: room.channelIdx,
         password: pwRef.current,
       }),
@@ -89,8 +91,8 @@ export default function ProtectedModal({
       socket.emit(
         "chat_enter",
         JSON.stringify({
-          userNickname: "intra_id",
-          userIdx: 3,
+          userNickname: userState.nickname,
+          userIdx: userState.userIdx,
           channelIdx: room.channelIdx,
           password: pwRef.current,
         }),

--- a/frontend/components/main/room_list/ProtectedModal.tsx
+++ b/frontend/components/main/room_list/ProtectedModal.tsx
@@ -13,7 +13,7 @@ import "./ProtectedModal.css";
 import { Box, Typography } from "@mui/material";
 import LockRoundedIcon from "@mui/icons-material/LockRounded";
 import { useRoom } from "@/context/RoomContext";
-import { IChatRoom } from "@/type/type";
+import { IChatRoom, Mode } from "@/type/type";
 import { socket } from "@/app/page";
 import { useUser } from "@/context/UserContext";
 
@@ -53,7 +53,7 @@ export default function ProtectedModal({
   setFail: Dispatch<SetStateAction<boolean>>;
   fail: boolean;
 }) {
-  const { roomDispatch } = useRoom();
+  const { roomState, roomDispatch } = useRoom();
   const { userState } = useUser();
   const pwRef = useRef("");
 
@@ -74,9 +74,25 @@ export default function ProtectedModal({
       }),
       (statusCode: number) => {
         if (statusCode === 200) {
+          if (
+            roomState.currentRoom &&
+            roomState.currentRoom.mode !== Mode.PRIVATE
+          ) {
+            socket.emit(
+              "chat_goto_lobby",
+              JSON.stringify({
+                channelIdx: roomState.currentRoom.channelIdx,
+                userIdx: userState.userIdx,
+              }),
+              (ret: any) => {
+                console.log("chat_goto_lobby ret : ", ret);
+              }
+            );
+          }
           handleClose();
           setFail(false);
           roomDispatch({ type: "SET_CUR_ROOM", value: room });
+          roomDispatch({ type: "SET_IS_OPEN", value: true });
         } else {
           setFail(true);
         }
@@ -98,9 +114,25 @@ export default function ProtectedModal({
         }),
         (statusCode: number) => {
           if (statusCode === 200) {
+            if (
+              roomState.currentRoom &&
+              roomState.currentRoom.mode !== Mode.PRIVATE
+            ) {
+              socket.emit(
+                "chat_goto_lobby",
+                JSON.stringify({
+                  channelIdx: roomState.currentRoom.channelIdx,
+                  userIdx: userState.userIdx,
+                }),
+                (ret: any) => {
+                  console.log("chat_goto_lobby ret : ", ret);
+                }
+              );
+            }
             handleClose();
             setFail(false);
             roomDispatch({ type: "SET_CUR_ROOM", value: room });
+            roomDispatch({ type: "SET_IS_OPEN", value: true });
           } else {
             setFail(true);
           }

--- a/frontend/components/main/room_list/ProtectedModal.tsx
+++ b/frontend/components/main/room_list/ProtectedModal.tsx
@@ -46,12 +46,14 @@ export default function ProtectedModal({
   room,
   setFail,
   fail,
+  RoomEnter,
 }: {
   open: boolean;
   handleClose: () => void;
   room: IChatRoom;
   setFail: Dispatch<SetStateAction<boolean>>;
   fail: boolean;
+  RoomEnter: (room: IChatRoom) => void;
 }) {
   const { roomState, roomDispatch } = useRoom();
   const { userState } = useUser();
@@ -72,27 +74,11 @@ export default function ProtectedModal({
         channelIdx: room.channelIdx,
         password: pwRef.current,
       }),
-      (statusCode: number) => {
-        if (statusCode === 200) {
-          if (
-            roomState.currentRoom &&
-            roomState.currentRoom.mode !== Mode.PRIVATE
-          ) {
-            socket.emit(
-              "chat_goto_lobby",
-              JSON.stringify({
-                channelIdx: roomState.currentRoom.channelIdx,
-                userIdx: userState.userIdx,
-              }),
-              (ret: any) => {
-                console.log("chat_goto_lobby ret : ", ret);
-              }
-            );
-          }
+      (ret: number) => {
+        if (ret === 200) {
+          RoomEnter(room);
           handleClose();
           setFail(false);
-          roomDispatch({ type: "SET_CUR_ROOM", value: room });
-          roomDispatch({ type: "SET_IS_OPEN", value: true });
         } else {
           setFail(true);
         }
@@ -112,27 +98,11 @@ export default function ProtectedModal({
           channelIdx: room.channelIdx,
           password: pwRef.current,
         }),
-        (statusCode: number) => {
-          if (statusCode === 200) {
-            if (
-              roomState.currentRoom &&
-              roomState.currentRoom.mode !== Mode.PRIVATE
-            ) {
-              socket.emit(
-                "chat_goto_lobby",
-                JSON.stringify({
-                  channelIdx: roomState.currentRoom.channelIdx,
-                  userIdx: userState.userIdx,
-                }),
-                (ret: any) => {
-                  console.log("chat_goto_lobby ret : ", ret);
-                }
-              );
-            }
+        (ret: number) => {
+          if (ret === 200) {
+            RoomEnter(room);
             handleClose();
             setFail(false);
-            roomDispatch({ type: "SET_CUR_ROOM", value: room });
-            roomDispatch({ type: "SET_IS_OPEN", value: true });
           } else {
             setFail(true);
           }

--- a/frontend/components/main/room_list/ProtectedModal.tsx
+++ b/frontend/components/main/room_list/ProtectedModal.tsx
@@ -13,7 +13,7 @@ import "./ProtectedModal.css";
 import { Box, Typography } from "@mui/material";
 import LockRoundedIcon from "@mui/icons-material/LockRounded";
 import { useRoom } from "@/context/RoomContext";
-import { IChatRoom } from "@/context/RoomContext";
+import { IChatRoom } from "@/type/type";
 import { socket } from "@/app/page";
 import { useUser } from "@/context/UserContext";
 

--- a/frontend/components/main/room_list/Room.tsx
+++ b/frontend/components/main/room_list/Room.tsx
@@ -120,9 +120,22 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
             }),
             (json: any) => {
               // 아직 안정해짐
-              if (roomState.currentRoom !== room) {
-                roomDispatch({ type: "SET_CUR_ROOM", value: room });
+              if (
+                roomState.currentRoom &&
+                roomState.currentRoom.mode !== Mode.PRIVATE
+              ) {
+                socket.emit(
+                  "chat_goto_lobby",
+                  JSON.stringify({
+                    channelIdx: roomState.currentRoom.channelIdx,
+                    userIdx: userState.userIdx,
+                  }),
+                  (ret: any) => {
+                    console.log("chat_goto_lobby ret : ", ret);
+                  }
+                );
               }
+              roomDispatch({ type: "SET_CUR_ROOM", value: room });
               roomDispatch({ type: "SET_IS_OPEN", value: true });
             }
           );

--- a/frontend/components/main/room_list/Room.tsx
+++ b/frontend/components/main/room_list/Room.tsx
@@ -68,7 +68,6 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
 
   useEffect(() => {
     const ChatEnter = (json: IChatEnter) => {
-      console.log("ChatEnter : ", json);
       roomDispatch({ type: "SET_CUR_MEM", value: json.member });
       roomDispatch({ type: "SET_ADMIN_ARY", value: json.admin });
       //channelIdx 안보내줘도 될듯?
@@ -195,7 +194,6 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
     }
   };
 
-  console.log("adminAry : ", roomState.adminAry);
   return (
     <>
       <button

--- a/frontend/components/main/room_list/Room.tsx
+++ b/frontend/components/main/room_list/Room.tsx
@@ -98,35 +98,35 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
 
   //TODO : 0명 되는 경우
 
-  useEffect(() => {
-    const GoToLobby = (json: IChatRoom[]) => {
-      roomDispatch({ type: "SET_NON_DM_ROOMS", value: json });
-    };
-    socket.on("chat_goto_lobby", GoToLobby);
+  // useEffect(() => {
+  //   const GoToLobby = (json: IChatRoom[]) => {
+  //     roomDispatch({ type: "SET_NON_DM_ROOMS", value: json });
+  //   };
+  //   socket.on("chat_goto_lobby", GoToLobby);
 
-    return () => {
-      socket.off("chat_goto_lobby", GoToLobby);
-    };
-  }, []);
+  //   return () => {
+  //     socket.off("chat_goto_lobby", GoToLobby);
+  //   };
+  // }, []);
 
   const RoomClick = (room: IChatRoom) => {
-    if (room.mode !== Mode.PROTECTED) {
-      if (room.mode === Mode.PRIVATE) {
-        socket.emit(
-          "chat_get_DM",
-          JSON.stringify({
-            channelIdx: room.channelIdx,
-          }),
-          (json: any) => {
-            // 아직 안정해짐
-            if (roomState.currentRoom !== room) {
-              roomDispatch({ type: "SET_CUR_ROOM", value: room });
+    if (roomState.currentRoom !== room) {
+      if (room.mode !== Mode.PROTECTED) {
+        if (room.mode === Mode.PRIVATE) {
+          socket.emit(
+            "chat_get_DM",
+            JSON.stringify({
+              channelIdx: room.channelIdx,
+            }),
+            (json: any) => {
+              // 아직 안정해짐
+              if (roomState.currentRoom !== room) {
+                roomDispatch({ type: "SET_CUR_ROOM", value: room });
+              }
+              roomDispatch({ type: "SET_IS_OPEN", value: true });
             }
-            roomDispatch({ type: "SET_IS_OPEN", value: true });
-          }
-        );
-      } else {
-        if (roomState.currentRoom !== room) {
+          );
+        } else {
           socket.emit(
             "chat_enter",
             JSON.stringify({
@@ -136,8 +136,10 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
             }),
             (statusCode: number) => {
               if (statusCode === 200) {
-                //  전에 들어갔던 방이 있으면 그 방에서 탈퇴되게
-                if (roomState.currentRoom) {
+                if (
+                  roomState.currentRoom &&
+                  roomState.currentRoom.mode !== Mode.PRIVATE
+                ) {
                   socket.emit(
                     "chat_goto_lobby",
                     JSON.stringify({
@@ -155,9 +157,9 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
             }
           );
         }
+      } else {
+        handleOpen();
       }
-    } else {
-      handleOpen();
     }
   };
 

--- a/frontend/components/main/room_list/Room.tsx
+++ b/frontend/components/main/room_list/Room.tsx
@@ -99,16 +99,16 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
 
   //TODO : 0명 되는 경우
 
-  // useEffect(() => {
-  //   const GoToLobby = (json: IChatRoom[]) => {
-  //     roomDispatch({ type: "SET_NON_DM_ROOMS", value: json });
-  //   };
-  //   socket.on("chat_goto_lobby", GoToLobby);
+  useEffect(() => {
+    const GoToLobby = (json: IChatRoom[]) => {
+      roomDispatch({ type: "SET_NON_DM_ROOMS", value: json });
+    };
+    socket.on("chat_goto_lobby", GoToLobby);
 
-  //   return () => {
-  //     socket.off("chat_goto_lobby", GoToLobby);
-  //   };
-  // }, []);
+    return () => {
+      socket.off("chat_goto_lobby", GoToLobby);
+    };
+  }, []);
 
   const RoomClick = (room: IChatRoom) => {
     if (roomState.currentRoom !== room) {

--- a/frontend/components/main/room_list/Room.tsx
+++ b/frontend/components/main/room_list/Room.tsx
@@ -13,6 +13,7 @@ import {
 import { IChatRoom, Mode } from "@/context/RoomContext";
 import { socket } from "@/app/page";
 import Alert from "@mui/material/Alert";
+import { useUser } from "@/context/UserContext";
 
 export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
   const [open, setOpen] = useState(false);
@@ -20,6 +21,7 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
   const [showAlert, setShowAlert] = useState<boolean>(false);
   const [newMem, setNewMem] = useState("");
   const { roomState, roomDispatch } = useRoom();
+  const { userState } = useUser();
 
   useEffect(() => {
     const ChatEnterNoti = (data: IChatEnterNoti) => {
@@ -31,7 +33,7 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
     return () => {
       socket.off("chat_enter_noti", ChatEnterNoti);
     };
-  }); // TODO : 위치?
+  });
 
   useEffect(() => {
     if (showAlert) {
@@ -114,8 +116,8 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
         socket.emit(
           "chat_enter",
           JSON.stringify({
-            userNickname: "jeekim",
-            userIdx: 98364,
+            userNickname: userState.nickname,
+            userIdx: userState.userIdx,
             channelIdx: room.channelIdx,
           }),
           (statusCode: number) => {

--- a/frontend/components/main/room_list/Room.tsx
+++ b/frontend/components/main/room_list/Room.tsx
@@ -11,6 +11,8 @@ import {
   IChatEnter,
   IChatEnterNoti,
   alert,
+  lock,
+  clickedLock,
 } from "@/type/type";
 import { socket } from "@/app/page";
 import Alert from "@mui/material/Alert";
@@ -182,14 +184,36 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
 
   return (
     <>
-      <button key={idx} className="item" onClick={() => RoomClick(room)}>
-        <div className="roomidx">{leftPadding(room.channelIdx)}</div>
+      <button
+        key={idx}
+        className={
+          roomState.currentRoom?.channelIdx === room.channelIdx
+            ? "clickeditem"
+            : "item"
+        }
+        onClick={() => RoomClick(room)}
+      >
+        <div
+          className={
+            roomState.currentRoom?.channelIdx === room.channelIdx
+              ? "clickedroomidx"
+              : "roomidx"
+          }
+        >
+          {leftPadding(room.channelIdx)}
+        </div>
         <div className="owner">
           {room.owner ? room.owner : room.targetNickname}'s
         </div>
         <div className="lock">
           {room.mode === Mode.PROTECTED ? (
-            <LockRoundedIcon sx={{ height: "13px", color: "#afb2b3" }} />
+            <LockRoundedIcon
+              sx={
+                roomState.currentRoom?.channelIdx === room.channelIdx
+                  ? clickedLock
+                  : lock
+              }
+            />
           ) : (
             ""
           )}

--- a/frontend/components/main/room_list/Room.tsx
+++ b/frontend/components/main/room_list/Room.tsx
@@ -104,6 +104,7 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
           (json: any) => {
             // 아직 안정해짐
             if (roomState.currentRoom !== room) {
+              //  전에 들어갔던 방이 있으면 그 방에서 탈퇴되게
               roomDispatch({ type: "SET_CUR_ROOM", value: room });
             }
             roomDispatch({ type: "SET_IS_OPEN", value: true });

--- a/frontend/components/main/room_list/Room.tsx
+++ b/frontend/components/main/room_list/Room.tsx
@@ -3,14 +3,15 @@
 import { useEffect, useState, useRef } from "react";
 import LockRoundedIcon from "@mui/icons-material/LockRounded";
 import ProtectedModal from "./ProtectedModal";
+import { useRoom } from "@/context/RoomContext";
 import {
+  IChatRoom,
+  Mode,
   IChatDmEnter,
   IChatEnter,
   IChatEnterNoti,
   alert,
-  useRoom,
-} from "@/context/RoomContext";
-import { IChatRoom, Mode } from "@/context/RoomContext";
+} from "@/type/type";
 import { socket } from "@/app/page";
 import Alert from "@mui/material/Alert";
 import { useUser } from "@/context/UserContext";

--- a/frontend/components/main/room_list/Room.tsx
+++ b/frontend/components/main/room_list/Room.tsx
@@ -68,7 +68,9 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
 
   useEffect(() => {
     const ChatEnter = (json: IChatEnter) => {
+      console.log("ChatEnter : ", json);
       roomDispatch({ type: "SET_CUR_MEM", value: json.member });
+      roomDispatch({ type: "SET_ADMIN_ARY", value: json.admin });
       //channelIdx 안보내줘도 될듯?
     };
     socket.on("chat_enter", ChatEnter);
@@ -102,7 +104,9 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
   //TODO : 0명 되는 경우
 
   useEffect(() => {
+    // const GoToLobby = (json?: IChatRoom[]) => {
     const GoToLobby = (json: IChatRoom[]) => {
+      console.log("GoToLobby : ", json);
       roomDispatch({ type: "SET_NON_DM_ROOMS", value: json });
     };
     socket.on("chat_goto_lobby", GoToLobby);
@@ -182,6 +186,7 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
     }
   };
 
+  console.log("adminAry : ", roomState.adminAry);
   return (
     <>
       <button

--- a/frontend/components/main/room_list/Room.tsx
+++ b/frontend/components/main/room_list/Room.tsx
@@ -101,10 +101,19 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
     };
   }, []);
 
-  //TODO : 0명 되는 경우
+  useEffect(() => {
+    const NoMember = (json: IChatRoom[]) => {
+      console.log("NoMember : ", json);
+      roomDispatch({ type: "SET_NON_DM_ROOMS", value: json });
+    };
+    socket.on("BR_chat_room_delete", NoMember);
+
+    return () => {
+      socket.off("BR_chat_room_delete", NoMember);
+    };
+  }, []);
 
   useEffect(() => {
-    // const GoToLobby = (json?: IChatRoom[]) => {
     const GoToLobby = (json: IChatRoom[]) => {
       console.log("GoToLobby : ", json);
       roomDispatch({ type: "SET_NON_DM_ROOMS", value: json });

--- a/frontend/components/main/room_list/Room.tsx
+++ b/frontend/components/main/room_list/Room.tsx
@@ -113,8 +113,8 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
         socket.emit(
           "chat_enter",
           JSON.stringify({
-            userNickname: "hoslim",
-            userIdx: 3,
+            userNickname: "jeekim",
+            userIdx: 98364,
             channelIdx: room.channelIdx,
           }),
           (statusCode: number) => {

--- a/frontend/components/main/room_list/Room.tsx
+++ b/frontend/components/main/room_list/Room.tsx
@@ -78,6 +78,7 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
 
   useEffect(() => {
     const ChatDmEnter = (json: IChatDmEnter) => {
+      console.log("ChatDmEnter");
       roomDispatch({
         type: "SET_CUR_DM_MEM",
         value: {
@@ -89,10 +90,10 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
         },
       });
     };
-    socket.on("check_dm", ChatDmEnter);
+    socket.on("chat_get_DM", ChatDmEnter);
 
     return () => {
-      socket.off("check_dm", ChatDmEnter);
+      socket.off("chat_get_DM", ChatDmEnter);
     };
   }, []);
 
@@ -120,23 +121,26 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
             }),
             (json: any) => {
               // 아직 안정해짐
-              if (
-                roomState.currentRoom &&
-                roomState.currentRoom.mode !== Mode.PRIVATE
-              ) {
-                socket.emit(
-                  "chat_goto_lobby",
-                  JSON.stringify({
-                    channelIdx: roomState.currentRoom.channelIdx,
-                    userIdx: userState.userIdx,
-                  }),
-                  (ret: any) => {
-                    console.log("chat_goto_lobby ret : ", ret);
-                  }
-                );
+              if (json === 200) {
+                console.log("dm click");
+                if (
+                  roomState.currentRoom &&
+                  roomState.currentRoom.mode !== Mode.PRIVATE
+                ) {
+                  socket.emit(
+                    "chat_goto_lobby",
+                    JSON.stringify({
+                      channelIdx: roomState.currentRoom.channelIdx,
+                      userIdx: userState.userIdx,
+                    }),
+                    (ret: any) => {
+                      console.log("chat_goto_lobby ret : ", ret);
+                    }
+                  );
+                }
+                roomDispatch({ type: "SET_CUR_ROOM", value: room });
+                roomDispatch({ type: "SET_IS_OPEN", value: true });
               }
-              roomDispatch({ type: "SET_CUR_ROOM", value: room });
-              roomDispatch({ type: "SET_IS_OPEN", value: true });
             }
           );
         } else {

--- a/frontend/components/main/room_list/RoomList.css
+++ b/frontend/components/main/room_list/RoomList.css
@@ -101,6 +101,10 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.item:disabled {
+  background-color: #7b8aa9;
+  color: rgba(255, 255, 255, 0.294);
+}
 
 .roomidx {
   display: inline-block;

--- a/frontend/components/main/room_list/RoomList.css
+++ b/frontend/components/main/room_list/RoomList.css
@@ -63,7 +63,7 @@
 }
 
 .roomclicked {
-  background-color: #1c408f;
+  background-color: #1c478e;
   border-radius: 10px;
   height: 43vh;
   bottom: 0;
@@ -101,9 +101,26 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.item:disabled {
+
+.clickeditem {
+  font-family: "crazy";
+  display: flex;
+  align-items: center;
+
+  /* background-color: #67dbfb; */
   background-color: #7b8aa9;
+  border-radius: 10px;
+  height: 50px;
+  border: 0px;
+  margin: 8px auto;
+  width: 100%;
+  /* color: black; */
   color: rgba(255, 255, 255, 0.294);
+  font-size: 18px;
+  padding-left: 10px;
+  padding-right: 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .roomidx {
@@ -114,6 +131,15 @@
   font-family: "crazy";
   vertical-align: middle;
   color: rgb(255, 221, 0);
+}
+.clickedroomidx {
+  display: inline-block;
+  width: 17%;
+  margin: auto;
+  font-size: 16px;
+  font-family: "crazy";
+  vertical-align: middle;
+  color: rgba(255, 255, 255, 0.294);
 }
 .owner {
   width: 70%;

--- a/frontend/components/main/room_list/RoomTypeButton.tsx
+++ b/frontend/components/main/room_list/RoomTypeButton.tsx
@@ -2,9 +2,10 @@
 
 import { useEffect, useState } from "react";
 import Rooms from "./Rooms";
-import { IChatRoom, useRoom } from "@/context/RoomContext";
+import { useRoom } from "@/context/RoomContext";
 import { socket } from "@/app/page";
 import { useUser } from "@/context/UserContext";
+import { IChatRoom } from "@/type/type";
 
 export default function RoomTypeButton() {
   const { roomState, roomDispatch } = useRoom();

--- a/frontend/components/main/room_list/RoomTypeButton.tsx
+++ b/frontend/components/main/room_list/RoomTypeButton.tsx
@@ -13,8 +13,8 @@ export default function RoomTypeButton() {
   const { userState } = useUser();
 
   useEffect(() => {
-    const ChatGetDmRoomList = (json?: IChatRoom[]) => {
-      json ? roomDispatch({ type: "SET_DM_ROOMS", value: json }) : null;
+    const ChatGetDmRoomList = (payload?: IChatRoom[]) => {
+      payload ? roomDispatch({ type: "SET_DM_ROOMS", value: payload }) : null;
     };
     socket.on("chat_get_DMList", ChatGetDmRoomList);
 
@@ -28,8 +28,10 @@ export default function RoomTypeButton() {
   };
 
   useEffect(() => {
-    const ChatGetRoomList = (json?: IChatRoom[]) => {
-      json ? roomDispatch({ type: "SET_NON_DM_ROOMS", value: json }) : null;
+    const ChatGetRoomList = (payload?: IChatRoom[]) => {
+      payload
+        ? roomDispatch({ type: "SET_NON_DM_ROOMS", value: payload })
+        : null;
     };
     socket.on("chat_get_roomList", ChatGetRoomList);
 
@@ -39,7 +41,7 @@ export default function RoomTypeButton() {
   }, []);
 
   const NonDmBtnClick = () => {
-    socket.emit("chat_get_roomList", (status_code: number) => {});
+    socket.emit("chat_get_roomList", (ret: number) => {});
     OnClick(true);
   };
 
@@ -50,9 +52,8 @@ export default function RoomTypeButton() {
         userNickname: userState.nickname,
         userIdx: userState.userIdx,
       }),
-      (status_code: any) => {
-        // 아직 안 정해짐
-        console.log(status_code);
+      (ret: number) => {
+        console.log(ret);
       }
     );
     OnClick(false);

--- a/frontend/components/main/room_list/Rooms.tsx
+++ b/frontend/components/main/room_list/Rooms.tsx
@@ -6,7 +6,8 @@ import "@/components/main/room_list/RoomList.css";
 import MemberList from "../member_list/MemberList";
 import CreateRoomButton from "./CreateRoomButton";
 import Room from "./Room";
-import { IChatRoom, useRoom } from "@/context/RoomContext";
+import { useRoom } from "@/context/RoomContext";
+import { IChatRoom } from "@/type/type";
 
 export default function Rooms({
   currentRoomList,

--- a/frontend/components/public/Layout.tsx
+++ b/frontend/components/public/Layout.tsx
@@ -52,14 +52,15 @@ const Layout = () => {
     if (localStorage.getItem("loggedIn")) {
       socket.emit(
         "main_enter",
-        JSON.stringify({ intra: localStorage.getItem("intra") }),
+        // JSON.stringify({ intra: localStorage.getItem("intra") }),
+        JSON.stringify({ intra: userState.nickname }),
         (ret: number) => {
           if (ret === 200) {
           }
         }
       );
     }
-  }, [localStorage.getItem("loggedIn")]);
+  }, []);
 
   return (
     <Box sx={{ display: "flex" }}>

--- a/frontend/components/public/Layout.tsx
+++ b/frontend/components/public/Layout.tsx
@@ -62,6 +62,7 @@ interface IUserObject {
   nickname: string;
   userIdx: number;
 }
+
 interface IMaindata {
   channelList: IChatRoom[];
   friendList: IFriend[];
@@ -100,10 +101,19 @@ const Layout = () => {
   //미세한 찰나일 것임.!
 
   useEffect(() => {
-    if (state.isLoggedIn) {
-      socket.emit("main_enter", JSON.stringify({ intra: "jeekim" }), () => {});
+    // if (state.isLoggedIn) {
+    if (localStorage.getItem("loggedIn")) {
+      socket.emit(
+        "main_enter",
+        JSON.stringify({ intra: localStorage.getItem("intra") }),
+        (ret: number) => {
+          if (ret === 200) {
+          }
+        }
+      );
     }
-  }, [state.isLoggedIn]);
+  }, [localStorage.getItem("loggedIn")]);
+  // }, [state.isLoggedIn]);
 
   return (
     <Box sx={{ display: "flex" }}>

--- a/frontend/components/public/Layout.tsx
+++ b/frontend/components/public/Layout.tsx
@@ -62,8 +62,6 @@ const Layout = () => {
     }
   }, []);
 
-  console.log(userState.nickname);
-
   return (
     <Box sx={{ display: "flex" }}>
       <Stack

--- a/frontend/components/public/Layout.tsx
+++ b/frontend/components/public/Layout.tsx
@@ -101,7 +101,7 @@ const Layout = () => {
 
   useEffect(() => {
     if (state.isLoggedIn) {
-      socket.emit("main_enter", JSON.stringify({ intra: "hoslim" }), () => {});
+      socket.emit("main_enter", JSON.stringify({ intra: "jeekim" }), () => {});
     }
   }, [state.isLoggedIn]);
 

--- a/frontend/components/public/Layout.tsx
+++ b/frontend/components/public/Layout.tsx
@@ -50,10 +50,10 @@ const Layout = () => {
 
   useEffect(() => {
     if (localStorage.getItem("loggedIn")) {
+      console.log(userState.nickname);
       socket.emit(
         "main_enter",
-        // JSON.stringify({ intra: localStorage.getItem("intra") }),
-        JSON.stringify({ intra: userState.nickname }),
+        JSON.stringify({ intra: localStorage.getItem("intra") }),
         (ret: number) => {
           if (ret === 200) {
           }
@@ -61,6 +61,8 @@ const Layout = () => {
       );
     }
   }, []);
+
+  console.log(userState.nickname);
 
   return (
     <Box sx={{ display: "flex" }}>

--- a/frontend/components/public/Layout.tsx
+++ b/frontend/components/public/Layout.tsx
@@ -16,59 +16,7 @@ import { useRoom } from "@/context/RoomContext";
 import { UserProvider, useUser } from "@/context/UserContext";
 import { useFriend } from "@/context/FriendContext";
 import { socket } from "@/app/page";
-
-export const main = {
-  main0: "#67DBFB",
-  main1: "#55B7EB",
-  main2: "#4292DA",
-  main3: "#2C70DD",
-  main4: "#265ECF",
-  main5: "#214C97",
-  main6: "#183C77",
-  main7: "#48a0ed",
-  main8: "#64D9F9",
-};
-
-export enum Permission {
-  OWNER = "owner",
-  ADMIN = "admin",
-  MEMBER = "member",
-}
-
-export enum Mode {
-  PRIVATE = "private",
-  PUBLIC = "public",
-  PROTECTED = "protected",
-}
-
-export interface IChatRoom {
-  channelIdx: number;
-  owner: string;
-  mode: Mode;
-}
-
-interface IFriend {
-  friendNickname: string;
-  isOnline: boolean;
-}
-
-interface IBlock {
-  targetNickname: string;
-  targetIdx: number;
-}
-
-interface IUserObject {
-  imgUri: string;
-  nickname: string;
-  userIdx: number;
-}
-
-interface IMaindata {
-  channelList: IChatRoom[];
-  friendList: IFriend[];
-  blockList: IBlock[];
-  userObject: IUserObject;
-}
+import { IMaindata } from "@/type/type";
 
 const Layout = () => {
   const { state } = useAuth();
@@ -101,7 +49,6 @@ const Layout = () => {
   //미세한 찰나일 것임.!
 
   useEffect(() => {
-    // if (state.isLoggedIn) {
     if (localStorage.getItem("loggedIn")) {
       socket.emit(
         "main_enter",
@@ -113,7 +60,6 @@ const Layout = () => {
       );
     }
   }, [localStorage.getItem("loggedIn")]);
-  // }, [state.isLoggedIn]);
 
   return (
     <Box sx={{ display: "flex" }}>

--- a/frontend/context/RoomContext.tsx
+++ b/frontend/context/RoomContext.tsx
@@ -14,6 +14,7 @@ interface RoomContextData {
   currentRoomMemberList: IMember[];
   isOpen: boolean;
   currentDmRoomMemberList: IDmMemList | null;
+  adminAry : string[];
 }
 
 type RoomAction =
@@ -23,7 +24,8 @@ type RoomAction =
   | { type: "SET_CUR_MEM"; value: IMember[] }
   | { type: "SET_IS_OPEN"; value: boolean }
   | { type: "ADD_ROOM"; value: IChatRoom }
-  | { type: "SET_CUR_DM_MEM"; value: IDmMemList };
+  | { type: "SET_CUR_DM_MEM"; value: IDmMemList }
+  | { type: "SET_ADMIN_ARY"; value: string[] }
 
 const initialState: RoomContextData = {
   dmRooms: [],
@@ -32,6 +34,7 @@ const initialState: RoomContextData = {
   currentRoomMemberList: [],
   isOpen: false,
   currentDmRoomMemberList: null,
+  adminAry : []
 };
 
 const RoomReducer = (roomState: RoomContextData, action: RoomAction) => {
@@ -53,6 +56,8 @@ const RoomReducer = (roomState: RoomContextData, action: RoomAction) => {
       };
     case "SET_CUR_DM_MEM":
       return { ...roomState, currentDmRoomMemberList: action.value };
+    case "SET_ADMIN_ARY":
+      return { ...roomState, adminAry: action.value };
     default:
       return roomState;
   }

--- a/frontend/context/RoomContext.tsx
+++ b/frontend/context/RoomContext.tsx
@@ -22,6 +22,7 @@ export interface IMember {
   userIdx: number | undefined;
   nickname: string | undefined;
   imgUri: string | undefined;
+  permission?: Permission | undefined;
 }
 
 export interface IChatRoom {

--- a/frontend/context/RoomContext.tsx
+++ b/frontend/context/RoomContext.tsx
@@ -1,3 +1,4 @@
+import { IChatRoom, IDmMemList, IMember } from "@/type/type";
 import {
   ReactNode,
   createContext,
@@ -5,102 +6,6 @@ import {
   useEffect,
   useReducer,
 } from "react";
-
-export enum Mode {
-  PRIVATE = "private",
-  PUBLIC = "public",
-  PROTECTED = "protected",
-}
-
-export enum Permission {
-  OWNER = "owner",
-  ADMIN = "admin",
-  MEMBER = "member",
-}
-
-export interface IMember {
-  userIdx: number | undefined;
-  nickname: string | undefined;
-  imgUri: string | undefined;
-  permission?: Permission | undefined;
-}
-
-export interface IChatRoom {
-  owner: string;
-  targetNickname?: string;
-  channelIdx: number;
-  mode: Mode;
-}
-
-export interface IChatEnter {
-  member: IMember[];
-  channelIdx: number;
-}
-
-export interface IChatEnterNoti {
-  member: IMember[];
-  newMember: string;
-}
-
-export interface IChatRoomAdmin {
-  userIdx: number;
-  grant: boolean;
-  admin: string[];
-}
-
-export interface IChatGetRoom {
-  owner?: string;
-  targetNickname?: string;
-  channelIdx: number;
-  mode: Mode;
-}
-
-export interface IChatGetRoomList {
-  channels: IChatRoom[];
-}
-
-export interface IChatMute {
-  channelList?: IChatGetRoom[];
-}
-
-export interface IChatKick {
-  targetNickname: string;
-  targetIdx: number;
-  leftMember: IMember[];
-}
-
-export interface IDmMemList {
-  userIdx1: number;
-  userIdx2: number;
-  userNickname1: string;
-  userNickname2: string;
-  imgUrl: string;
-}
-
-export interface IChatDmEnter {
-  // Message[] {
-  // 	message {
-  // 		sender : string,
-  // 		msg : string
-  // 	},
-  // 	...
-  // }, 이 부분은 주전님이 타입 정해주세요
-  // channelIdx : number; currentRoom이 있어서 필요성을 느끼지 못하지만,
-  //  이 부분도 필요하시면 주석해제하시고요!
-
-  userIdx1: number;
-  userIdx2: number;
-  userNickname1: string;
-  userNickname2: string;
-  imgUrl: string;
-}
-
-export const alert = {
-  position: "absolute" as "absolute",
-  top: "100%",
-  left: "50%",
-  transform: "translate(-50%, -100%)",
-};
 
 interface RoomContextData {
   dmRooms: IChatRoom[];

--- a/frontend/context/RoomContext.tsx
+++ b/frontend/context/RoomContext.tsx
@@ -42,7 +42,11 @@ export interface IChatEnterNoti {
   newMember: string;
 }
 
-export interface IChatRoomAdmin {}
+export interface IChatRoomAdmin {
+  userIdx: number;
+  grant: boolean;
+  admin: string[];
+}
 
 export interface IChatGetRoom {
   owner?: string;

--- a/frontend/context/RoomContext.tsx
+++ b/frontend/context/RoomContext.tsx
@@ -113,7 +113,6 @@ type RoomAction =
   | { type: "SET_CUR_MEM"; value: IMember[] }
   | { type: "SET_IS_OPEN"; value: boolean }
   | { type: "ADD_ROOM"; value: IChatRoom }
-  | { type: "ADD_CUR_MEM"; value: IMember }
   | { type: "SET_CUR_DM_MEM"; value: IDmMemList };
 
 const initialState: RoomContextData = {
@@ -142,17 +141,8 @@ const RoomReducer = (roomState: RoomContextData, action: RoomAction) => {
         ...roomState,
         nonDmRooms: [...roomState.nonDmRooms, action.value],
       };
-    case "ADD_CUR_MEM":
-      return {
-        ...roomState,
-        currentRoomMemberList: [
-          ...roomState.currentRoomMemberList,
-          action.value,
-        ],
-      };
     case "SET_CUR_DM_MEM":
       return { ...roomState, currentDmRoomMemberList: action.value };
-
     default:
       return roomState;
   }

--- a/frontend/context/RoomContext.tsx
+++ b/frontend/context/RoomContext.tsx
@@ -14,7 +14,7 @@ interface RoomContextData {
   currentRoomMemberList: IMember[];
   isOpen: boolean;
   currentDmRoomMemberList: IDmMemList | null;
-  adminAry : string[];
+  adminAry: { nickname: string }[];
 }
 
 type RoomAction =
@@ -25,7 +25,7 @@ type RoomAction =
   | { type: "SET_IS_OPEN"; value: boolean }
   | { type: "ADD_ROOM"; value: IChatRoom }
   | { type: "SET_CUR_DM_MEM"; value: IDmMemList }
-  | { type: "SET_ADMIN_ARY"; value: string[] }
+  | { type: "SET_ADMIN_ARY"; value: { nickname: string }[] };
 
 const initialState: RoomContextData = {
   dmRooms: [],
@@ -34,7 +34,7 @@ const initialState: RoomContextData = {
   currentRoomMemberList: [],
   isOpen: false,
   currentDmRoomMemberList: null,
-  adminAry : []
+  adminAry: [],
 };
 
 const RoomReducer = (roomState: RoomContextData, action: RoomAction) => {

--- a/frontend/type/type.tsx
+++ b/frontend/type/type.tsx
@@ -95,7 +95,10 @@ export interface IChatGetRoomList {
 }
 
 export interface IChatMute {
-  channelList?: IChatGetRoom[];
+  // emit - roomId
+  targetNickname : string,
+	targetIdx : number,
+	mute : boolean
 }
 
 export interface IChatKick {

--- a/frontend/type/type.tsx
+++ b/frontend/type/type.tsx
@@ -70,6 +70,7 @@ export interface IChatRoom {
 export interface IChatEnter {
   member: IMember[];
   channelIdx: number;
+  admin: { nickname: string }[];
 }
 
 export interface IChatEnterNoti {

--- a/frontend/type/type.tsx
+++ b/frontend/type/type.tsx
@@ -96,9 +96,9 @@ export interface IChatGetRoomList {
 
 export interface IChatMute {
   // emit - roomId
-  targetNickname : string,
-	targetIdx : number,
-	mute : boolean
+  targetNickname: string;
+  targetIdx: number;
+  mute: boolean;
 }
 
 export interface IChatKick {
@@ -138,4 +138,14 @@ export const alert = {
   top: "100%",
   left: "50%",
   transform: "translate(-50%, -100%)",
+};
+
+export const lock = {
+  height: "13px",
+  color: "#afb2b3",
+};
+
+export const clickedLock = {
+  height: "13px",
+  color: "rgba(255, 255, 255, 0.294)",
 };

--- a/frontend/type/type.tsx
+++ b/frontend/type/type.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+export const main = {
+  main0: "#67DBFB",
+  main1: "#55B7EB",
+  main2: "#4292DA",
+  main3: "#2C70DD",
+  main4: "#265ECF",
+  main5: "#214C97",
+  main6: "#183C77",
+  main7: "#48a0ed",
+  main8: "#64D9F9",
+};
+
+export enum Permission {
+  OWNER = "owner",
+  ADMIN = "admin",
+  MEMBER = "member",
+}
+
+export enum Mode {
+  PRIVATE = "private",
+  PUBLIC = "public",
+  PROTECTED = "protected",
+}
+
+// export interface IChatRoom {
+//   channelIdx: number;
+//   owner: string;
+//   mode: Mode;
+// }
+
+export interface IFriend {
+  friendNickname: string;
+  isOnline: boolean;
+}
+
+export interface IBlock {
+  targetNickname: string;
+  targetIdx: number;
+}
+
+export interface IUserObject {
+  imgUri: string;
+  nickname: string;
+  userIdx: number;
+}
+
+export interface IMaindata {
+  channelList: IChatRoom[];
+  friendList: IFriend[];
+  blockList: IBlock[];
+  userObject: IUserObject;
+}
+
+export interface IMember {
+  userIdx: number | undefined;
+  nickname: string | undefined;
+  imgUri: string | undefined;
+  permission?: Permission | undefined;
+}
+
+export interface IChatRoom {
+  owner: string;
+  targetNickname?: string;
+  channelIdx: number;
+  mode: Mode;
+}
+
+export interface IChatEnter {
+  member: IMember[];
+  channelIdx: number;
+}
+
+export interface IChatEnterNoti {
+  member: IMember[];
+  newMember: string;
+}
+
+export interface IChatRoomAdmin {
+  userIdx: number;
+  grant: boolean;
+  admin: string[];
+}
+
+export interface IChatGetRoom {
+  owner?: string;
+  targetNickname?: string;
+  channelIdx: number;
+  mode: Mode;
+}
+
+export interface IChatGetRoomList {
+  channels: IChatRoom[];
+}
+
+export interface IChatMute {
+  channelList?: IChatGetRoom[];
+}
+
+export interface IChatKick {
+  targetNickname: string;
+  targetIdx: number;
+  leftMember: IMember[];
+}
+
+export interface IDmMemList {
+  userIdx1: number;
+  userIdx2: number;
+  userNickname1: string;
+  userNickname2: string;
+  imgUrl: string;
+}
+
+export interface IChatDmEnter {
+  // Message[] {
+  // 	message {
+  // 		sender : string,
+  // 		msg : string
+  // 	},
+  // 	...
+  // }, 이 부분은 주전님이 타입 정해주세요
+  // channelIdx : number; currentRoom이 있어서 필요성을 느끼지 못하지만,
+  //  이 부분도 필요하시면 주석해제하시고요!
+
+  userIdx1: number;
+  userIdx2: number;
+  userNickname1: string;
+  userNickname2: string;
+  imgUrl: string;
+}
+
+export const alert = {
+  position: "absolute" as "absolute",
+  top: "100%",
+  left: "50%",
+  transform: "translate(-50%, -100%)",
+};

--- a/frontend/type/type.tsx
+++ b/frontend/type/type.tsx
@@ -81,7 +81,7 @@ export interface IChatEnterNoti {
 export interface IChatRoomAdmin {
   userIdx: number;
   grant: boolean;
-  admin: string[];
+  admin: { nickname: string }[];
 }
 
 export interface IChatGetRoom {


### PR DESCRIPTION
멤버 우클릭시 드롭다운인 set/unset admin, kick, ban, mute api
**user입장에서 했을때**
(상대방에게 정상적으로 띄워지는지는 다음 pr때)

- 필요없는 코드 삭제
- css class 추가
- 변경/ 완성된 mute, kick, ban, admin api 적용
- 관리자에게 별테두리 아이콘 붙임
- 본인과 채널 owner는 우클릭시 드롭다운 안보이게함
- 이제 admin 배열 받기 때문에 chat_get_grant 부분 필요없을것같은데 혹시 몰라 주석처리해놓음
- localStorage에 user idx, user nickname 저장해놓고 이걸로 socket 만들고, main_enter_0때 socket.emit() 때 사용.
- 그리고 socket.emit() 두번째 인자 상수로 보냈던거 다 저장데이터 사용하는 식으로 변경
- Layout.tsx와 내가 작성한 파일들에 있는 타입들 모두 type.tsx파일에 모아둠
- chat_goto_lobby 적용 !dm 방에서 public/protected 방 들어갈때
- 들어가있는 방 다시 방 목록에서 클릭하면 아무런 처리 안되게 함
-[] 맨 처음엔 잘 적용됐는데, ex) 1번방 있다가 2번방 들어갔을때 2번방 버튼 계속 누르면 계속 들어가는 로직 작동돼서 다음 pr때 막아야 함...
- 서버로부터 받는 admin 배열 room쪽 전역변수로 관리
- 어떤 방 성공적으로 들어가면 방 목록에서 그 방은 색이 바뀜
- 방에 0명 남으면 지워주는 api 적용
- admin이면 메뉴 3개만 보이게 함. (owner는 4개 보임)
- main 타입 사용한 부분에서 경로 변경해줌
- 토큰 받을때 받는 유저 데이터를 userState로 저장해봤지만, 처음 메인화면 접속시 문제 없는데, 새로고침했을때 다 날라가서 localStorage 쓰는게 나을것같아서 다시 돌립
- socket.emit했을때 서버에서 return 하는 데이터 ret로, socket.on했을때 받는 데이터는 payload로 이름 변경