### PR TITLE
99 feat chat window

### DIFF
--- a/frontend/components/main/chat_window/BottomField/BottomField.tsx
+++ b/frontend/components/main/chat_window/BottomField/BottomField.tsx
@@ -33,19 +33,19 @@ const BottomField = ({ setMsgs }: Props) => {
 
   useEffect(() => {
     const messageHandler = (chatFromServer: IChat) => {
+      const result = roomState.currentRoomMemberList.find(person => person.userIdx === chatFromServer.senderIdx)
       if (roomState.currentRoom?.mode === "private") {
         const chat = {
           channelIdx: chatFromServer.channelIdx,
           senderIdx: chatFromServer.sender === roomState.currentDmRoomMemberList?.userIdx1
             ? roomState.currentDmRoomMemberList?.userIdx1
             : roomState.currentDmRoomMemberList?.userIdx2,
-          sender: chatFromServer.sender,
+          sender: result?.nickname,
           msg: chatFromServer.msg,
           msgDate: chatFromServer.msgDate, }
         setMsgs((prevChats: any) => [chat, ...prevChats]); // <----- any type 나중 변경 필요.
         console.log(chat);
       } else {
-          const result = roomState.currentRoomMemberList.find(person => person.userIdx === chatFromServer.senderIdx)
         if (result?.nickname) {
           const chat = {
             channelIdx: chatFromServer.channelIdx,

--- a/frontend/components/main/chat_window/BottomField/BottomField.tsx
+++ b/frontend/components/main/chat_window/BottomField/BottomField.tsx
@@ -33,19 +33,25 @@ const BottomField = ({ setMsgs }: Props) => {
 
   useEffect(() => {
     const messageHandler = (chatFromServer: IChat) => {
-      const result = roomState.currentRoomMemberList.find(person => person.userIdx === chatFromServer.senderIdx)
-      if (roomState.currentRoom?.mode === "private") {
+        let result;
+        if (roomState.currentRoom?.mode === "private") {
+          if (roomState.currentDmRoomMemberList?.userIdx1 === chatFromServer.senderIdx) {
+            result = roomState.currentDmRoomMemberList?.userNickname1
+          } else if (roomState.currentDmRoomMemberList?.userIdx2 === chatFromServer.senderIdx) {
+            result = roomState.currentDmRoomMemberList?.userNickname2
+          } else return ;
         const chat = {
           channelIdx: chatFromServer.channelIdx,
           senderIdx: chatFromServer.sender === roomState.currentDmRoomMemberList?.userIdx1
             ? roomState.currentDmRoomMemberList?.userIdx1
             : roomState.currentDmRoomMemberList?.userIdx2,
-          sender: result?.nickname,
+          sender: result,
           msg: chatFromServer.msg,
           msgDate: chatFromServer.msgDate, }
         setMsgs((prevChats: any) => [chat, ...prevChats]); // <----- any type 나중 변경 필요.
         console.log(chat);
       } else {
+        result = roomState.currentRoomMemberList.find(person => person.userIdx === chatFromServer.senderIdx)
         if (result?.nickname) {
           const chat = {
             channelIdx: chatFromServer.channelIdx,

--- a/frontend/components/main/chat_window/ChatField/DmChat.tsx
+++ b/frontend/components/main/chat_window/ChatField/DmChat.tsx
@@ -7,6 +7,7 @@ import { Dispatch, SetStateAction } from "react";
 import { IChat } from "../ChatWindow";
 import axios from "axios";
 import { useInitMsg } from "@/context/InitMsgContext";
+import {IDMChatFromServer} from "@/type/type"
 
 interface Props {
   msgs: IChat[];
@@ -63,12 +64,12 @@ const DmChat = ({ msgs, setMsgs }: Props) => {
   // 첫 메세지 20개 불러오는 로직
   useEffect(() => {
     if (!initMsgState.dmEnterEntry) return;
-    const list: IChat[] = initMsgState.dmEnterEntry?.message.map(
-      (data: any) => {
+    const list: IChat[] = initMsgState.dmEnterEntry.message.map(
+      (data: IDMChatFromServer) => {
         const payload: IChat = {
           channelIdx: initMsgState.dmEnterEntry?.channelIdx,
           senderIdx:
-            data.sender === roomState.currentDmRoomMemberList?.userIdx1
+            data.sender === roomState.currentDmRoomMemberList?.userNickname1
               ? roomState.currentDmRoomMemberList?.userIdx1
               : roomState.currentDmRoomMemberList?.userIdx2,
           sender: data.sender,

--- a/frontend/components/main/chat_window/ChatField/DmChat.tsx
+++ b/frontend/components/main/chat_window/ChatField/DmChat.tsx
@@ -155,7 +155,7 @@ const DmChat = ({ msgs, setMsgs }: Props) => {
           </ul>
         );
       })}
-      <div ref={observerTarget}>"여기가 타겟자리"</div>
+      <div ref={observerTarget}></div>
 
       {loading === true && (
         <Typography style={{ color: "white" }} component={"div"}>

--- a/frontend/components/main/chat_window/ChatField/DmChat.tsx
+++ b/frontend/components/main/chat_window/ChatField/DmChat.tsx
@@ -86,17 +86,21 @@ const DmChat = ({ msgs, setMsgs }: Props) => {
 
   // 이전 대화기록을 불러오거나, 새로 채팅을 송수신하게되면 그때마다 불러와진 대화기록 중 제일 오래된 메세지의 Date를 가져온다.
   useEffect(() => {
-    console.log("!!!")
+    console.log("!!!");
     if (msgs.length > 0) {
       const lastIdx = msgs.length - 1;
-      console.log("lastidx", lastIdx)
+      console.log("lastidx", lastIdx);
       const lastElement = msgs[lastIdx];
-      console.log("lastIdxMsg", lastElement)
+      console.log("lastIdxMsg", lastElement);
       setLastDate(() => lastElement.msgDate);
       // console.log("메세지 갱신됐어, 라스트 데이트도 업뎃함");
       // console.log(Date.now(), lastDate);
     }
   }, [msgs, lastDate]);
+
+  useEffect(() => {
+    console.log(msgs);
+  }, [msgs]);
 
   return (
     <Box
@@ -129,7 +133,12 @@ const DmChat = ({ msgs, setMsgs }: Props) => {
             >
               {
                 <Typography variant="h6">
-                  {value.sender + ": " + value.msg}
+                  {value.senderIdx ===
+                  roomState.currentDmRoomMemberList?.userIdx1
+                    ? roomState.currentDmRoomMemberList?.userNickname1
+                    : roomState.currentDmRoomMemberList?.userNickname2 +
+                      ": " +
+                      value.msg}
                 </Typography>
               }
             </div>

--- a/frontend/components/main/chat_window/ChatWindow.tsx
+++ b/frontend/components/main/chat_window/ChatWindow.tsx
@@ -7,6 +7,8 @@ import LobbyWindow from "./LobbyWindow";
 import { Box } from "@mui/material";
 import { useRoom } from "@/context/RoomContext";
 import { useEffect, useState } from "react";
+import { alert } from "@/type/type";
+import Alert from "@mui/material/Alert";
 
 export interface IChat {
   channelIdx: number | undefined;
@@ -20,6 +22,7 @@ const ChatWindow = () => {
   const { roomState } = useRoom();
   const [prevRoom, setPrevRoom] = useState(0);
   const [msgs, setMsgs] = useState<IChat[]>([]);
+  const [showAlert, setShowAlert] = useState<boolean>(false);
 
   // 방전환시 채팅내역 초기화
   useEffect(() => {
@@ -30,31 +33,37 @@ const ChatWindow = () => {
     if (!roomState.currentRoom) setMsgs([]);
     // else if (roomState.currentRoom.channelIdx !== prevRoom) setMsgs([]);
     setPrevRoom(roomState.currentRoom?.channelIdx);
-    console.log("[ChatWindow:33] last content of 방전환시 채팅내역 초기화")
+    console.log("[ChatWindow:33] last content of 방전환시 채팅내역 초기화");
   }, [roomState.currentRoom?.channelIdx]);
 
   useEffect(() => {
     console.log("chatwindow", msgs);
   }, [msgs]);
 
-  useEffect(()=> {
-    if (roomState.isOpen === true)
-      console.log("[ChatWindow:41] isOpen is true")
-    else
-      console.log("[ChatWindow:43] isOpen is false")
-  }, [roomState.isOpen])
-
   useEffect(() => {
+    if (roomState.isOpen === true)
+      console.log("[ChatWindow:41] isOpen is true");
+    else console.log("[ChatWindow:43] isOpen is false");
+  }, [roomState.isOpen]);
 
-  }, [])
+  useEffect(() => {}, []);
 
   return (
     <Box sx={{ margin: "0", padding: "0", height: "60vh", minWidth: "300px" }}>
       {roomState.isOpen ? (
         <>
-          <RoomTitleField setMsgs={setMsgs} />
+          <RoomTitleField
+            setMsgs={setMsgs}
+            showAlert={showAlert}
+            setShowAlert={setShowAlert}
+          />
           <ChatField msgs={msgs} setMsgs={setMsgs} />
           <BottomField setMsgs={setMsgs} />
+          {showAlert ? (
+            <Alert sx={alert} severity="info" style={{ width: "333px" }}>
+              You can't change the password
+            </Alert>
+          ) : null}
         </>
       ) : (
         <LobbyWindow />

--- a/frontend/components/main/chat_window/ChatWindow.tsx
+++ b/frontend/components/main/chat_window/ChatWindow.tsx
@@ -26,27 +26,29 @@ const ChatWindow = () => {
 
   // 방전환시 채팅내역 초기화
   useEffect(() => {
-    console.log("!!!", roomState.currentRoom?.channelIdx);
+    // console.log("!!!", roomState.currentRoom?.channelIdx);
     if (!roomState.currentRoom?.channelIdx) return;
-    console.log("prev", prevRoom);
-    console.log("channel", roomState.currentRoom.channelIdx);
-    if (!roomState.currentRoom) setMsgs([]);
-    // else if (roomState.currentRoom.channelIdx !== prevRoom) setMsgs([]);
+    if (roomState.currentRoom.mode !== "private" && roomState.currentRoom.channelIdx !== prevRoom)
+      setMsgs([]);
     setPrevRoom(roomState.currentRoom?.channelIdx);
-    console.log("[ChatWindow:33] last content of 방전환시 채팅내역 초기화");
+    // console.log("prev", prevRoom);
+    // console.log("channel", roomState.currentRoom.channelIdx);
+    // if (!roomState.currentRoom) setMsgs([]);
+    // else if (roomState.currentRoom.channelIdx !== prevRoom) setMsgs([]);
+    // console.log("[ChatWindow:33] last content of 방전환시 채팅내역 초기화");
   }, [roomState.currentRoom?.channelIdx]);
 
-  useEffect(() => {
-    console.log("chatwindow", msgs);
-  }, [msgs]);
+  // useEffect(() => {
+  //   console.log("chatwindow", msgs);
+  // }, [msgs]);
 
-  useEffect(() => {
-    if (roomState.isOpen === true)
-      console.log("[ChatWindow:41] isOpen is true");
-    else console.log("[ChatWindow:43] isOpen is false");
-  }, [roomState.isOpen]);
+  // useEffect(() => {
+  //   if (roomState.isOpen === true)
+  //     console.log("[ChatWindow:41] isOpen is true");
+  //   else console.log("[ChatWindow:43] isOpen is false");
+  // }, [roomState.isOpen]);
 
-  useEffect(() => {}, []);
+  // useEffect(() => {}, []);
 
   return (
     <Box sx={{ margin: "0", padding: "0", height: "60vh", minWidth: "300px" }}>

--- a/frontend/components/main/chat_window/ChatWindow.tsx
+++ b/frontend/components/main/chat_window/ChatWindow.tsx
@@ -39,6 +39,17 @@ const ChatWindow = () => {
   }, [roomState.currentRoom?.channelIdx]);
 
   // useEffect(() => {
+  //   console.log("!!!", roomState.currentRoom?.channelIdx);
+  //   if (!roomState.currentRoom?.channelIdx) return;
+  //   console.log("prev", prevRoom);
+  //   console.log("channel", roomState.currentRoom.channelIdx);
+  //   if (!roomState.currentRoom) setMsgs([]);
+  //   // else if (roomState.currentRoom.channelIdx !== prevRoom) setMsgs([]);
+  //   setPrevRoom(roomState.currentRoom?.channelIdx);
+  //   console.log("[ChatWindow:33] last content of 방전환시 채팅내역 초기화");
+  // }, [roomState.currentRoom?.channelIdx]);
+
+  // useEffect(() => {
   //   console.log("chatwindow", msgs);
   // }, [msgs]);
 

--- a/frontend/components/main/chat_window/RoomTitleField/EditRoomModal.tsx
+++ b/frontend/components/main/chat_window/RoomTitleField/EditRoomModal.tsx
@@ -2,7 +2,7 @@
 
 import "@/components/main/room_list/RoomList.css";
 import { useRoom } from "@/context/RoomContext";
-import { IChatRoom } from "@/type/type";
+import { IChatRoom, ReturnMsgDto } from "@/type/type";
 import { Box, Button, Card, Stack, TextField, Typography } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import { socket } from "@/app/page";
@@ -21,20 +21,41 @@ const style = {
   p: 4,
 };
 
-export default function EditRoomModal({ prop }: { prop: () => void }) {
+export default function EditRoomModal({
+  prop,
+  showAlert,
+  setShowAlert,
+}: {
+  prop: () => void;
+  showAlert: boolean;
+  setShowAlert: React.Dispatch<React.SetStateAction<boolean>>;
+}) {
   const { roomState, roomDispatch } = useRoom();
   const [value, setValue] = useState("");
   const { userState } = useUser();
   const payload = {
     channelIdx: roomState.currentRoom?.channelIdx,
-    senderIdx: userState.userIdx, // [번경필요]나중에 나의 userIdx 로 변경필요
-    changedPassword: value,
+    userIdx: userState.userIdx, // [번경필요]나중에 나의 userIdx 로 변경필요
+    changePassword: value,
   };
+
+  useEffect(() => {
+    const changingPw = (res: IChatRoom[]) => {
+      roomDispatch({ type: "SET_NON_DM_ROOMS", value: res });
+    };
+
+    socket.on("BR_chat_room_password", changingPw);
+  }, []);
 
   const handleClose = () => {
     prop();
-    socket.emit("BR_chat_room_password", payload);
-    console.log("방설정변경 pw: ", value);
+    socket.emit("BR_chat_room_password", payload, (ret: ReturnMsgDto) => {
+      if (ret.code === 200) {
+        console.log("pw changing success");
+      } else {
+        setShowAlert(true);
+      }
+    });
   };
 
   useEffect(() => {

--- a/frontend/components/main/chat_window/RoomTitleField/EditRoomModal.tsx
+++ b/frontend/components/main/chat_window/RoomTitleField/EditRoomModal.tsx
@@ -45,6 +45,9 @@ export default function EditRoomModal({
     };
 
     socket.on("BR_chat_room_password", changingPw);
+    return () => {
+      socket.off("BR_chat_room_password", changingPw);
+    }
   }, []);
 
   const handleClose = () => {

--- a/frontend/components/main/chat_window/RoomTitleField/RoomNameStack.tsx
+++ b/frontend/components/main/chat_window/RoomTitleField/RoomNameStack.tsx
@@ -6,13 +6,14 @@ import Stack from "@mui/material/Stack";
 
 import { styled } from "@mui/material/styles";
 import { useRoom } from "@/context/RoomContext";
+import { Typography } from "@mui/material";
 
 const Item = styled(Paper)(({ theme }) => ({
   backgroundColor: theme.palette.mode === "dark" ? "#1A2027" : "#fff",
   ...theme.typography.body2,
   padding: theme.spacing(1),
   textAlign: "center",
-  color: theme.palette.text.secondary,
+  color: "yellow",
 }));
 
 export default function DirectionStack() {
@@ -28,7 +29,7 @@ export default function DirectionStack() {
     } else if (idx && idx > 99 && idx <= 999) {
       displayIdx = idx.toString();
     }
-    return <div>{displayIdx}</div>;
+    return <Typography>{displayIdx}</Typography>
   };
   return (
     <div className="stack_box">

--- a/frontend/components/main/chat_window/RoomTitleField/RoomTitleField.css
+++ b/frontend/components/main/chat_window/RoomTitleField/RoomTitleField.css
@@ -45,8 +45,10 @@
 }
 
 .room_setting {
+  padding-bottom: 5px;
 }
 
 .room_exit {
-  padding-right: 3px;
+  padding-right: 6px;
+  padding-bottom: 5px;
 }

--- a/frontend/components/main/chat_window/RoomTitleField/RoomTitleField.tsx
+++ b/frontend/components/main/chat_window/RoomTitleField/RoomTitleField.tsx
@@ -15,16 +15,24 @@ import { socket } from "@/app/page";
 import { useUser } from "@/context/UserContext";
 import { IChat } from "../ChatWindow";
 
-interface Props {
-  setMsgs: Dispatch<SetStateAction<IChat[]>>;
-}
+// interface Props {
+//   setMsgs: Dispatch<SetStateAction<IChat[]>>;
+// }
 export enum Mode {
   PRIVATE = "private",
   PUBLIC = "public",
   PROTECTED = "protected",
 }
 
-const RoomTitleField = ({ setMsgs }: Props) => {
+const RoomTitleField = ({
+  setMsgs,
+  showAlert,
+  setShowAlert,
+}: {
+  setMsgs: Dispatch<SetStateAction<IChat[]>>;
+  showAlert: boolean;
+  setShowAlert: React.Dispatch<React.SetStateAction<boolean>>;
+}) => {
   const [open, setOpen] = useState(false);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
@@ -122,7 +130,12 @@ const RoomTitleField = ({ setMsgs }: Props) => {
           ) : null}
         </div>
         <div className="room_setting">
-          {roomState.currentRoom?.mode === "private" ? null : <SettingIconButton />}
+          {roomState.currentRoom?.mode === "private" ? null : (
+            <SettingIconButton
+              showAlert={showAlert}
+              setShowAlert={setShowAlert}
+            />
+          )}
         </div>
         <div className="room_exit">
           <IconButton aria-label="leave room" onClick={leaveRoom}>

--- a/frontend/components/main/chat_window/RoomTitleField/RoomTitleField.tsx
+++ b/frontend/components/main/chat_window/RoomTitleField/RoomTitleField.tsx
@@ -4,7 +4,7 @@ import Stack from "./RoomNameStack";
 import Typography from "@mui/material/Typography";
 import VpnKeyTwoToneIcon from "@mui/icons-material/VpnKeyTwoTone";
 import "./RoomTitleField.css";
-import { IconButton } from "@mui/material";
+import { IconButton, Button } from "@mui/material";
 import SettingIconButton from "./SettingIconButton";
 import { useEffect, useState } from "react";
 import DeleteForeverIcon from "@mui/icons-material/DeleteForever";
@@ -138,9 +138,10 @@ const RoomTitleField = ({
           )}
         </div>
         <div className="room_exit">
-          <IconButton aria-label="leave room" onClick={leaveRoom}>
+          {/* <IconButton aria-label="leave room" onClick={leaveRoom}>
             <DeleteForeverIcon />
-          </IconButton>
+          </IconButton> */}
+          <Button variant="contained" size="small" onClick={leaveRoom}>lobby</Button>
         </div>
       </div>
     </div>

--- a/frontend/components/main/chat_window/RoomTitleField/RoomTitleField.tsx
+++ b/frontend/components/main/chat_window/RoomTitleField/RoomTitleField.tsx
@@ -68,6 +68,14 @@ const RoomTitleField = ({
       } else
         console.log("[RoomTItleField] there isn't roomState.currentRoom case");
     };
+    socket.on("chat_goto_lobby", leaveHandler);
+
+    return () => {
+      socket.off("chat_goto_lobby", leaveHandler);
+    };
+  }, []);
+
+  useEffect(() => {
     const leaveAndDeleteHandler = (channels: IChatRoom[]) => {
       console.log(
         "[RoomTItleField] leaveAndDeleteHandler on! chanel : ",
@@ -80,11 +88,9 @@ const RoomTitleField = ({
       } else
         console.log("[RoomTItleField] there isn't roomState.currentRoom case");
     };
-    socket.on("chat_goto_lobby", leaveHandler);
     socket.on("BR_chat_room_delete", leaveAndDeleteHandler);
 
     return () => {
-      socket.off("chat_goto_lobby", leaveHandler);
       socket.off("BR_chat_room_delete", leaveAndDeleteHandler);
     };
   });
@@ -101,12 +107,17 @@ const RoomTitleField = ({
   }, [userState.nickname]);
 
   const leaveRoom = () => {
-    const payload = {
-      channelIdx: roomState.currentRoom?.channelIdx,
-      userIdx: userState.userIdx, // [작업필요] 추후 나의 userIdx로 교체필요
-    };
-    socket.emit("chat_goto_lobby", payload);
     console.log("[RoomTItleField] click leaveroom");
+    if (roomState.currentRoom?.mode !== "private") {
+      const payload = {
+        channelIdx: roomState.currentRoom?.channelIdx,
+        userIdx: userState.userIdx, // [작업필요] 추후 나의 userIdx로 교체필요
+      };
+      socket.emit("chat_goto_lobby", payload);
+    } else {
+      roomDispatch({ type: "SET_CUR_ROOM", value: null });
+      roomDispatch({ type: "SET_IS_OPEN", value: false });
+    }
   };
 
   return (
@@ -141,7 +152,9 @@ const RoomTitleField = ({
           {/* <IconButton aria-label="leave room" onClick={leaveRoom}>
             <DeleteForeverIcon />
           </IconButton> */}
-          <Button variant="contained" size="small" onClick={leaveRoom}>lobby</Button>
+          <Button variant="contained" size="small" onClick={leaveRoom}>
+            lobby
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/components/main/chat_window/RoomTitleField/SettingIconButton.tsx
+++ b/frontend/components/main/chat_window/RoomTitleField/SettingIconButton.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import IconButton from "@mui/material/IconButton";
-import { useState, forwardRef } from "react";
+import { useState, forwardRef, useEffect } from "react";
 import Stack from "@mui/material/Stack";
 import { Modal } from "@mui/material";
 import SettingsIcon from "@mui/icons-material/Settings";
@@ -14,26 +14,50 @@ const Bar = forwardRef((props: any, ref: any) => (
   </span>
 ));
 
-export default function SettingIconButton() {
+export default function SettingIconButton({
+  showAlert,
+  setShowAlert,
+}: {
+  showAlert: boolean;
+  setShowAlert: React.Dispatch<React.SetStateAction<boolean>>;
+}) {
   const [open, setOpen] = useState(false);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
 
+  useEffect(() => {
+    if (showAlert) {
+      console.log("alret 켜졌다.");
+      const time = setTimeout(() => {
+        setShowAlert(false);
+        console.log("alret 꺼졌다.");
+      }, 3000);
+
+      return () => clearTimeout(time);
+    }
+  }, [showAlert]);
+
   return (
-    <Stack direction="row" spacing={0}>
-      <IconButton aria-label="setting" onClick={handleOpen}>
-        <SettingsIcon />
-      </IconButton>
-      <Modal
-        open={open}
-        onClose={handleClose}
-        aria-labelledby="modal-modal-title"
-        aria-describedby="modal-modal-description"
-      >
-        <Bar>
-          <EditRoomModal prop={handleClose} />
-        </Bar>
-      </Modal>
-    </Stack>
+    <>
+      <Stack direction="row" spacing={0}>
+        <IconButton aria-label="setting" onClick={handleOpen}>
+          <SettingsIcon />
+        </IconButton>
+        <Modal
+          open={open}
+          onClose={handleClose}
+          aria-labelledby="modal-modal-title"
+          aria-describedby="modal-modal-description"
+        >
+          <Bar>
+            <EditRoomModal
+              prop={handleClose}
+              showAlert={showAlert}
+              setShowAlert={setShowAlert}
+            />
+          </Bar>
+        </Modal>
+      </Stack>
+    </>
   );
 }

--- a/frontend/type/type.tsx
+++ b/frontend/type/type.tsx
@@ -135,7 +135,7 @@ export interface IDmMemList {
 
 export interface IDMChatFromServer {
   msg: string,
-  msgDate: Date,
+  msgDate: string,
   sender: string, // 원래는 IDX하기로했는데 백엔드 로직상 dm에서만 string
 }
 


### PR DESCRIPTION
## 구현사항
### 방설정
- [x] 비밀번호 변경
- [x] 변경시 방 타입 변경
- [x] owner가 아닌사람이 변경시도에는 안된다고 안내 토스트 알림

### 무한스크롤
- [x] 무한스크롤 구현완료 : 🚨 다중 상태관리가 까다롭다
- [ ] 종종 중복된 메세지 요청 및 응답이 온다. 리팩토링 필요

## 해결된 버그
### 채팅방 입장 / 나가기 / 전환
- [x] [문제상황] dm 과 일반방 전환시 채팅내역이 남아있음
- [x] [문제상황] 내가 메세지 보낼때는 undifeind로 이름이 표시됨.
- [x] DM방에서 방 나가기 안됨

### CSS
- [x] 로비로나가기 버튼 휴지통에서 lobby 버튼으로 복구완료