### PR TITLE
[FIX] not working click dm

### DIFF
--- a/frontend/components/public/Layout.tsx
+++ b/frontend/components/public/Layout.tsx
@@ -28,6 +28,7 @@ const Layout = () => {
     const MainEnter = (data: IMaindata) => {
       console.log("main_enter", data)
       roomDispatch({ type: "SET_NON_DM_ROOMS", value: data.channelList });
+      roomDispatch({ type: "SET_DM_ROOMS", value: data.dmChannelList })
       friendDispatch({ type: "SET_FRIENDLIST", value: data.friendList });
       friendDispatch({ type: "SET_BLOCKLIST", value: data.blockList });
       userDispatch({ type: "CHANGE_IMG", value: data.userObject.imgUri });

--- a/frontend/type/type.tsx
+++ b/frontend/type/type.tsx
@@ -55,6 +55,7 @@ export interface IUserObject {
 
 export interface IMaindata {
   channelList: IChatRoom[];
+  dmChannelList: IChatRoom[];
   friendList: IFriend[];
   blockList: IBlock[];
   userObject: IUserObject;


### PR DESCRIPTION
- chat_main에서 dm 방 목록도 받게 됨.

### 문제상황
dm 하기 버튼을 누르면, 이미 dm 방이 있는 상황에서리디렉션이 안된다.

### 원인
dm 채널 버튼을 누르고 프로필에서dm 하기 버튼을 누르면 잘 된다.
dm 채널 버튼을 한번도 누르지 않은상태에서는 안된다.
-> 프론트에서dm 채널 정보가 없어서 그런것!