### PR TITLE
[FIX] 상대 프로필에서 다른 사람의 닉네임이 뜬다.

### DIFF
--- a/frontend/components/main/friend_list/FriendProfile.tsx
+++ b/frontend/components/main/friend_list/FriendProfile.tsx
@@ -305,10 +305,9 @@ const FriendProfile = ({ prop }: { prop: IFriend }) => {
               mx={5}
             >
               <Image
-                // src="/seal.png" // mockdata
                 src={`${server_domain}/img/${
                   prop.friendIdx
-                }.png?${Date.now().toString()}`} // < !mockdata
+                }.png?${Date.now().toString()}`}
                 alt="user img"
                 width={100}
                 height={100}
@@ -327,15 +326,7 @@ const FriendProfile = ({ prop }: { prop: IFriend }) => {
                 }}
               >
                 닉네임: {friendData?.targetNickname}
-              </Typography>
-              <Typography>
-                상태:{" "}
-                {friendData?.isOnline === IOnlineStatus.ONLINE
-                  ? loginOn
-                  : friendData?.isOnline === IOnlineStatus.OFFLINE
-                  ? loginOff
-                  : ""}
-              </Typography>
+              </Typography> 
               <Stack direction={"row"} spacing={2}>
                 {/* <FriendGameButton prop={prop as IFriend} /> */}
                 <Button

--- a/frontend/components/main/member_list/MemberModal.tsx
+++ b/frontend/components/main/member_list/MemberModal.tsx
@@ -51,19 +51,10 @@ export default function MemberModal({
   person: IMember;
 }) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const [curFriend, setCurFriend] = useState<IFriend | null>(null);
   const { roomState, roomDispatch } = useRoom();
   const { userState } = useUser();
   const { friendState, friendDispatch } = useFriend();
   const { authState } = useAuth();
-
-  useEffect(() => {
-    setCurFriend({
-      friendNickname: person.nickname!,
-      friendIdx: person.userIdx!,
-      isOnline: IOnlineStatus.ONLINE,
-    });
-  }, []);
 
   const handleCloseModal = () => {
     setOpenModal(false);
@@ -272,15 +263,7 @@ export default function MemberModal({
                 textOverflow: "ellipsis",
               }}
             >
-              닉네임: {curFriend?.friendNickname}
-            </Typography>
-            <Typography>
-              상태:
-              {curFriend?.isOnline === IOnlineStatus.ONLINE
-                ? loginOn
-                : curFriend?.isOnline === IOnlineStatus.OFFLINE
-                ? loginOff
-                : ""}
+              닉네임: {person.nickname}
             </Typography>
             <Stack direction={"row"} spacing={2}>
               <MemberGameButton prop={person} />


### PR DESCRIPTION
### 문제원인
다른사람 프로필을 보고, 그 다음 사람의 프로필로 넘어갈때, memberModal 페이지 자체가 사라지지 않으므로, 재랜더링 되지 않음.
그러므로 useEffect()로 초기화만 걸어둔 부분이 실행이 안되고 nickname 이 갱신이 안됐음.

### (추가사항)정책 변경
상태 표시 상대프로필에선 안보이게. 오직 친구 리스트를 통해서만 확인 가능하게 변경