### PR TITLE
[FIX] show unproper nickname at gamelog

### DIFF
--- a/frontend/components/main/friend_list/FriendGameLog.tsx
+++ b/frontend/components/main/friend_list/FriendGameLog.tsx
@@ -205,7 +205,7 @@ const FriendGameLog = ({person}: {person:IFriend}) => {
                 >
                   <Typography sx={{ fontSize: "1.5rem" }}>
                     {/* 내닉네임 | 점수 : 점수 | 상대닉네임 */}
-                    {userState.nickname}{" "}
+                    {person.friendNickname}{" "}
                     {gameRecordData.score}{" "}
                     {gameRecordData.matchUserNickname}
                   </Typography>

--- a/frontend/components/main/member_list/MemberGameLog.tsx
+++ b/frontend/components/main/member_list/MemberGameLog.tsx
@@ -205,7 +205,7 @@ const MemberGameLog = ({person}: {person:IMember}) => {
                 >
                   <Typography sx={{ fontSize: "1.5rem" }}>
                     {/* 내닉네임 | 점수 : 점수 | 상대닉네임 */}
-                    {userState.nickname}{" "}
+                    {person.nickname}{" "}
                     {gameRecordData.score}{" "}
                     {gameRecordData.matchUserNickname}
                   </Typography>


### PR DESCRIPTION
- 멤버모달, 친구 리스트에서 프로필을 열었을때, 게임전적의 닉네임 부적절한 이름 표시되던 문제 해결