### PR TITLE
[FIX] secondauth 페이지 주소를 직접 입력해서 방문하는 경우 막아져 있지 않다.

### DIFF
--- a/frontend/hooks/useRequireAuth.ts
+++ b/frontend/hooks/useRequireAuth.ts
@@ -16,6 +16,7 @@ export const useRequireAuth = (redirectUrl: string = "/login") => {
       !document.URL.includes("/mypage") &&
       !document.URL.includes("/login") &&
       !document.URL.includes("/optionselect") &&
+      !document.URL.includes("/secondauth") &&
       !document.URL.includes("/inwaiting") &&
       !document.URL.includes("/init") &&
       !document.URL.includes("/home") &&


### PR DESCRIPTION
해결완료