### PR TITLE
isonline에 게임 상태 추가

### DIFF
--- a/frontend/app/gameresult/page.tsx
+++ b/frontend/app/gameresult/page.tsx
@@ -10,10 +10,11 @@ import axios from "axios";
 import { server_domain } from "../page";
 import { IGameLog } from "@/type/GameType";
 import { useAuth } from "@/context/AuthContext";
+import { ReturnMsgDto } from "@/type/RoomType";
 
 const GameResult = () => {
   const { gameState, gameDispatch } = useGame();
-  const { authState } = useAuth()
+  const { authState } = useAuth();
   const [client, setClient] = useState(false);
   const [gameLog, setGameLog] = useState<IGameLog | null>(null);
   const [user1Score, setUser1Score] = useState<number>(0);
@@ -22,8 +23,16 @@ const GameResult = () => {
   const router = useRouter();
 
   const BackToMain = () => {
-    authState.gameSocket!.disconnect()
+    authState.gameSocket!.disconnect();
     gameDispatch({ type: "SCORE_RESET" });
+    if (!authState.chatSocket) return;
+    authState.chatSocket.emit(
+      "BR_set_status_online",
+      {
+        userNickname: authState.userInfo.nickname,
+      },
+      (ret: ReturnMsgDto) => {}
+    );
     router.replace("/home?from=game");
   };
 

--- a/frontend/app/home/page.tsx
+++ b/frontend/app/home/page.tsx
@@ -13,7 +13,6 @@ import { server_domain } from "../page";
 import { IChatRoom, ReturnMsgDto } from "@/type/RoomType";
 import { useRoom } from "@/context/RoomContext";
 import secureLocalStorage from "react-secure-storage";
-import { useUser } from "@/context/UserContext";
 
 const Page = () => {
   const param = useSearchParams();
@@ -77,6 +76,14 @@ const Page = () => {
     }) => {
       if (answer === false) {
         authState.gameSocket!.disconnect();
+        if (!authState.chatSocket) return;
+        authState.chatSocket.emit(
+          "BR_set_status_online",
+          {
+            userNickname: authState.userInfo.nickname,
+          },
+          (ret: ReturnMsgDto) => {}
+        );
         closeModal();
       } else if (answer === true) {
         gameDispatch({ type: "SET_GAME_MODE", value: GameType.FRIEND });

--- a/frontend/app/optionselect/page.tsx
+++ b/frontend/app/optionselect/page.tsx
@@ -19,6 +19,7 @@ import { useAuth } from "@/context/AuthContext";
 import axios from "axios";
 import secureLocalStorage from "react-secure-storage";
 import { GameType, MapOption, SpeedOption } from "@/type/type";
+import { ReturnMsgDto } from "@/type/RoomType";
 
 // type SpeedOption = "speed1" | "speed2" | "speed3";
 // type MapOption = "map1" | "map2" | "map3";
@@ -80,7 +81,7 @@ const OptionSelect = () => {
     gameDispatch({ type: "SET_MAP_TYPE", value: selectedMapOption });
     gameDispatch({ type: "SCORE_RESET" });
 
-    console.log("mode", gameState.gameMode)
+    console.log("mode", gameState.gameMode);
 
     if (gameState.gameMode === GameType.FRIEND) {
       await axios({
@@ -109,9 +110,7 @@ const OptionSelect = () => {
           router.replace("/home?from=game");
         });
       return;
-    } else if (
-      gameState.gameMode === GameType.NORMAL
-    ) {
+    } else if (gameState.gameMode === GameType.NORMAL) {
       await axios({
         method: "post",
         url: `${server_domain}/game/normal-match`,
@@ -175,6 +174,14 @@ const OptionSelect = () => {
               backgroundColor: "White",
             }}
             onClick={() => {
+              if (!authState.chatSocket) return;
+              authState.chatSocket.emit(
+                "BR_set_status_online",
+                {
+                  userNickname: authState.userInfo.nickname,
+                },
+                (ret: ReturnMsgDto) => {}
+              );
               router.replace("/home?from=game");
             }}
           >

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -84,6 +84,7 @@ export default function HomePage() {
     //   return router.replace("/home");
     // }
     console.log("🙋🏻‍♂️ [app/page.tsx] go to login");
+    authState.chatSocket?.disconnect();
     return router.push("/login");
   }, []);
 

--- a/frontend/components/game/GameStartButton.tsx
+++ b/frontend/components/game/GameStartButton.tsx
@@ -10,18 +10,28 @@ import { ReturnMsgDto } from "@/type/RoomType";
 import { useUser } from "@/context/UserContext";
 import { useEffect } from "react";
 import { useFriend } from "@/context/FriendContext";
+import { IOnGame } from "@/type/type";
 
 const GameStartButton = () => {
   const router = useRouter();
   const { roomState, roomDispatch } = useRoom();
   const { authState } = useAuth();
   const { userState } = useUser();
+  const { friendState, friendDispatch } = useFriend();
 
   useEffect(() => {
-    const SetStatusOnGame = () => {};
+    const SetStatusOnGame = (payload: IOnGame) => {
+      const newFriendList = friendState.friendList.map((friend) => {
+        if (payload.userIdx === friend.friendIdx)
+          return { ...friend, isOnline: payload.isOnline };
+        else return friend;
+      });
+
+      friendDispatch({ type: "SET_FRIENDLIST", value: newFriendList });
+    };
 
     authState.chatSocket?.on("BR_set_status_ongame", SetStatusOnGame);
-  }, []);
+  }, [friendState.friendList]);
 
   const onClick = () => {
     if (!authState.chatSocket) return;

--- a/frontend/components/game/GameStartButton.tsx
+++ b/frontend/components/game/GameStartButton.tsx
@@ -35,7 +35,7 @@ const GameStartButton = () => {
         userNickname: userState.nickname,
       },
       (res: ReturnMsgDto) => {
-        console.log("GameStartButton : ", res);
+        // console.log("GameStartButton : ", res);
       }
     );
     if (roomState.currentRoom?.channelIdx) {
@@ -53,7 +53,7 @@ const GameStartButton = () => {
             roomDispatch({ type: "SET_IS_OPEN", value: false });
             roomDispatch({ type: "SET_CUR_ROOM", value: null });
           } else {
-            console.log("GameStartButton : ", ret.msg);
+            // console.log("GameStartButton : ", ret.msg);
           }
         }
       );

--- a/frontend/components/game/GameStartButton.tsx
+++ b/frontend/components/game/GameStartButton.tsx
@@ -7,14 +7,33 @@ import { useRoom } from "@/context/RoomContext";
 import { useAuth } from "@/context/AuthContext";
 import secureLocalStorage from "react-secure-storage";
 import { ReturnMsgDto } from "@/type/RoomType";
+import { useUser } from "@/context/UserContext";
+import { useEffect } from "react";
+import { useFriend } from "@/context/FriendContext";
 
 const GameStartButton = () => {
   const router = useRouter();
   const { roomState, roomDispatch } = useRoom();
   const { authState } = useAuth();
+  const { userState } = useUser();
+
+  useEffect(() => {
+    const SetStatusOnGame = () => {};
+
+    authState.chatSocket?.on("BR_set_status_ongame", SetStatusOnGame);
+  }, []);
 
   const onClick = () => {
-    console.log("hihi");
+    if (!authState.chatSocket) return;
+    authState.chatSocket.emit(
+      "BR_set_status_ongame",
+      {
+        userNickname: userState.nickname,
+      },
+      (res: ReturnMsgDto) => {
+        console.log("GameStartButton : ", res);
+      }
+    );
     if (roomState.currentRoom?.channelIdx) {
       authState.chatSocket!.emit(
         "chat_goto_lobby",

--- a/frontend/components/game/GameStartButton.tsx
+++ b/frontend/components/game/GameStartButton.tsx
@@ -21,13 +21,7 @@ const GameStartButton = () => {
 
   useEffect(() => {
     const SetStatusOnGame = (payload: IOnGame) => {
-      const newFriendList = friendState.friendList.map((friend) => {
-        if (payload.userIdx === friend.friendIdx)
-          return { ...friend, isOnline: payload.isOnline };
-        else return friend;
-      });
-
-      friendDispatch({ type: "SET_FRIENDLIST", value: newFriendList });
+      // console.log("SetStatusOnGame : ", payload);
     };
 
     authState.chatSocket?.on("BR_set_status_ongame", SetStatusOnGame);

--- a/frontend/components/main/InviteGame/FriendGameButton.tsx
+++ b/frontend/components/main/InviteGame/FriendGameButton.tsx
@@ -30,7 +30,7 @@ const FriendGameButton = ({ prop }: { prop: IFriend }) => {
         userNickname: userState.nickname,
       },
       (res: ReturnMsgDto) => {
-        console.log("GameStartButton : ", res);
+        // console.log("GameStartButton : ", res);
       }
     );
     authState.chatSocket.emit(
@@ -40,7 +40,7 @@ const FriendGameButton = ({ prop }: { prop: IFriend }) => {
         targetUserIdx: prop.friendIdx,
       },
       (res: ReturnMsgDto) => {
-        console.log("handleOpenModal : ", res);
+        // console.log("handleOpenModal : ", res);
         if (res.code == 200) {
           authState.gameSocket!.connect();
           openModal({
@@ -69,7 +69,7 @@ const FriendGameButton = ({ prop }: { prop: IFriend }) => {
       targetUserNickname: string;
       answer: boolean;
     }) => {
-      console.log("receive invite", answer);
+      // console.log("receive invite", answer);
       if (answer === false) {
         authState.gameSocket!.disconnect();
         if (!authState.chatSocket) return;
@@ -84,7 +84,7 @@ const FriendGameButton = ({ prop }: { prop: IFriend }) => {
       } else if (answer === true) {
         gameDispatch({ type: "SET_GAME_MODE", value: GameType.FRIEND });
         const target = { nick: targetUserNickname, id: targetUserIdx };
-        console.log("target", target);
+        // console.log("target", target);
         gameDispatch({ type: "B_PLAYER", value: target });
         if (roomState.currentRoom) {
           authState.chatSocket?.emit(
@@ -98,7 +98,7 @@ const FriendGameButton = ({ prop }: { prop: IFriend }) => {
                 roomDispatch({ type: "SET_IS_OPEN", value: false });
                 roomDispatch({ type: "SET_CUR_ROOM", value: null });
               } else {
-                console.log("FriendGoToLobby : ", res.msg);
+                // console.log("FriendGoToLobby : ", res.msg);
               }
             }
           );
@@ -109,7 +109,7 @@ const FriendGameButton = ({ prop }: { prop: IFriend }) => {
     };
 
     const FriendGoToLobby = (payload: IChatRoom[]) => {
-      console.log("FriendGoToLobby : ", payload);
+      // console.log("FriendGoToLobby : ", payload);
       roomDispatch({ type: "SET_NON_DM_ROOMS", value: payload });
     };
 

--- a/frontend/components/main/InviteGame/FriendGameButton.tsx
+++ b/frontend/components/main/InviteGame/FriendGameButton.tsx
@@ -12,6 +12,7 @@ import { GameType } from "@/type/type";
 import secureLocalStorage from "react-secure-storage";
 import { useRoom } from "@/context/RoomContext";
 import { IChatRoom, ReturnMsgDto } from "@/type/RoomType";
+import { useUser } from "@/context/UserContext";
 
 const FriendGameButton = ({ prop }: { prop: IFriend }) => {
   const router = useRouter();
@@ -19,9 +20,19 @@ const FriendGameButton = ({ prop }: { prop: IFriend }) => {
   const { openModal, closeModal } = useModalContext();
   const { gameDispatch } = useGame();
   const { roomState, roomDispatch } = useRoom();
+  const { userState } = useUser();
 
   const handleOpenModal = () => {
     if (!authState.chatSocket) return;
+    authState.chatSocket.emit(
+      "BR_set_status_ongame",
+      {
+        userNickname: userState.nickname,
+      },
+      (res: ReturnMsgDto) => {
+        console.log("FriendGameButton : ", res);
+      }
+    );
     authState.chatSocket.emit("chat_invite_ask", {
       myUserIdx: parseInt(secureLocalStorage.getItem("idx") as string),
       targetUserIdx: prop.friendIdx,

--- a/frontend/components/main/InviteGame/FriendGameButton.tsx
+++ b/frontend/components/main/InviteGame/FriendGameButton.tsx
@@ -30,17 +30,25 @@ const FriendGameButton = ({ prop }: { prop: IFriend }) => {
         userNickname: userState.nickname,
       },
       (res: ReturnMsgDto) => {
-        console.log("FriendGameButton : ", res);
+        console.log("GameStartButton : ", res);
       }
     );
-    authState.chatSocket.emit("chat_invite_ask", {
-      myUserIdx: parseInt(secureLocalStorage.getItem("idx") as string),
-      targetUserIdx: prop.friendIdx,
-    });
-    authState.gameSocket!.connect();
-    openModal({
-      children: <WaitAccept nickname={prop.friendNickname} />,
-    });
+    authState.chatSocket.emit(
+      "chat_invite_ask",
+      {
+        myUserIdx: parseInt(secureLocalStorage.getItem("idx") as string),
+        targetUserIdx: prop.friendIdx,
+      },
+      (res: ReturnMsgDto) => {
+        console.log("handleOpenModal : ", res);
+        if (res.code == 200) {
+          authState.gameSocket!.connect();
+          openModal({
+            children: <WaitAccept nickname={prop.friendNickname} />,
+          });
+        } else if (res.code === 400) alert("상대방이 게임 중 입니다.");
+      }
+    );
   };
 
   useEffect(() => {
@@ -77,12 +85,12 @@ const FriendGameButton = ({ prop }: { prop: IFriend }) => {
               channelIdx: roomState.currentRoom!.channelIdx,
               userIdx: parseInt(secureLocalStorage.getItem("idx") as string),
             },
-            (ret: ReturnMsgDto) => {
-              if (ret.code === 200) {
+            (res: ReturnMsgDto) => {
+              if (res.code === 200) {
                 roomDispatch({ type: "SET_IS_OPEN", value: false });
                 roomDispatch({ type: "SET_CUR_ROOM", value: null });
               } else {
-                console.log("FriendGoToLobby : ", ret.msg);
+                console.log("FriendGoToLobby : ", res.msg);
               }
             }
           );

--- a/frontend/components/main/InviteGame/FriendGameButton.tsx
+++ b/frontend/components/main/InviteGame/FriendGameButton.tsx
@@ -71,6 +71,15 @@ const FriendGameButton = ({ prop }: { prop: IFriend }) => {
     }) => {
       console.log("receive invite", answer);
       if (answer === false) {
+        authState.gameSocket!.disconnect();
+        if (!authState.chatSocket) return;
+        authState.chatSocket.emit(
+          "BR_set_status_online",
+          {
+            userNickname: userState.nickname,
+          },
+          (ret: ReturnMsgDto) => {}
+        );
         closeModal();
       } else if (answer === true) {
         gameDispatch({ type: "SET_GAME_MODE", value: GameType.FRIEND });

--- a/frontend/components/main/InviteGame/InviteGame.tsx
+++ b/frontend/components/main/InviteGame/InviteGame.tsx
@@ -2,7 +2,7 @@
 
 import { Button, Card, CardContent, Typography } from "@mui/material";
 import { useEffect } from "react";
-import { main } from "@/type/type";
+import { IOnGame, main } from "@/type/type";
 import { useRouter } from "next/navigation";
 import { useModalContext } from "@/context/ModalContext";
 import { useAuth } from "@/context/AuthContext";
@@ -10,6 +10,7 @@ import { useGame } from "@/context/GameContext";
 import { GameType } from "@/type/type";
 import secureLocalStorage from "react-secure-storage";
 import { useRoom } from "@/context/RoomContext";
+import { ReturnMsgDto } from "@/type/RoomType";
 
 const modalStyle = {
   position: "absolute" as "absolute",
@@ -29,7 +30,6 @@ const InviteGame = ({ nickname, idx }: { nickname: string; idx: number }) => {
   const { gameDispatch } = useGame();
   const { authState } = useAuth();
   const router = useRouter();
-  const { roomState } = useRoom();
 
   const handleYes = () => {
     if (!authState.chatSocket) return;
@@ -49,6 +49,14 @@ const InviteGame = ({ nickname, idx }: { nickname: string; idx: number }) => {
   const handleNo = () => {
     if (!authState.chatSocket) return;
     authState.chatSocket.emit(
+      "BR_set_status_online",
+      {
+        userNickname: authState.userInfo.nickname,
+      },
+      (ret: ReturnMsgDto) => {}
+    );
+
+    authState.chatSocket.emit(
       "chat_invite_answer",
       {
         inviteUserIdx: idx,
@@ -60,7 +68,13 @@ const InviteGame = ({ nickname, idx }: { nickname: string; idx: number }) => {
       }
     );
   };
-  
+
+  useEffect(() => {
+    if (!authState.chatSocket) return;
+    const SetStatusOnline = (payload: IOnGame) => {};
+    authState.chatSocket.on("BR_set_status_online", SetStatusOnline);
+  }, []);
+
   return (
     <>
       <Card

--- a/frontend/components/main/InviteGame/MemberGameButton.tsx
+++ b/frontend/components/main/InviteGame/MemberGameButton.tsx
@@ -29,7 +29,7 @@ const MemberGameButton = ({ prop }: { prop: IMember }) => {
         userNickname: userState.nickname,
       },
       (res: ReturnMsgDto) => {
-        console.log("MemberGameButton : ", res);
+        // console.log("MemberGameButton : ", res);
       }
     );
     authState.chatSocket.emit(
@@ -93,7 +93,7 @@ const MemberGameButton = ({ prop }: { prop: IMember }) => {
               roomDispatch({ type: "SET_IS_OPEN", value: false });
               roomDispatch({ type: "SET_CUR_ROOM", value: null });
             } else {
-              console.log("HomeGoToLobby : ", ret.msg);
+              // console.log("HomeGoToLobby : ", ret.msg);
             }
           }
         );
@@ -103,7 +103,7 @@ const MemberGameButton = ({ prop }: { prop: IMember }) => {
     };
 
     const MemGoToLobby = (payload: IChatRoom[]) => {
-      console.log("MemGoToLobby : ", payload);
+      // console.log("MemGoToLobby : ", payload);
       roomDispatch({ type: "SET_NON_DM_ROOMS", value: payload });
     };
     authState.chatSocket.on("chat_goto_lobby", MemGoToLobby);

--- a/frontend/components/main/InviteGame/MemberGameButton.tsx
+++ b/frontend/components/main/InviteGame/MemberGameButton.tsx
@@ -11,6 +11,7 @@ import { useGame } from "@/context/GameContext";
 import { GameType } from "@/type/type";
 import secureLocalStorage from "react-secure-storage";
 import { useRoom } from "@/context/RoomContext";
+import { useUser } from "@/context/UserContext";
 
 const MemberGameButton = ({ prop }: { prop: IMember }) => {
   const router = useRouter();
@@ -18,9 +19,19 @@ const MemberGameButton = ({ prop }: { prop: IMember }) => {
   const { openModal, closeModal } = useModalContext();
   const { gameDispatch } = useGame();
   const { roomState, roomDispatch } = useRoom();
+  const { userState } = useUser();
 
   const handleOpenModal = () => {
     if (!authState.chatSocket) return;
+    authState.chatSocket.emit(
+      "BR_set_status_ongame",
+      {
+        userNickname: userState.nickname,
+      },
+      (res: ReturnMsgDto) => {
+        console.log("MemberGameButton : ", res);
+      }
+    );
     authState.chatSocket.emit(
       "chat_invite_ask",
       {

--- a/frontend/components/main/InviteGame/MemberGameButton.tsx
+++ b/frontend/components/main/InviteGame/MemberGameButton.tsx
@@ -43,8 +43,12 @@ const MemberGameButton = ({ prop }: { prop: IMember }) => {
           openModal({
             children: <WaitAccept nickname={prop.nickname} />,
           });
+        } else if (res.msg === "Bad Request, target user is offline") {
+          // TODO : 알맞은 메시지 띄우기
+          alert("상대방이 오프라인입니다.");
+          closeModal();
         } else if (res.code === 400) {
-          alert("상대방이 게임 중 입니다.");
+          alert("상대방이 게임 중입니다.");
           closeModal();
         }
       }

--- a/frontend/components/main/InviteGame/MemberGameButton.tsx
+++ b/frontend/components/main/InviteGame/MemberGameButton.tsx
@@ -45,6 +45,7 @@ const MemberGameButton = ({ prop }: { prop: IMember }) => {
             children: <WaitAccept nickname={prop.nickname} />,
           });
         } else if (res.code === 400) {
+          alert("상대방이 게임 중 입니다.");
           closeModal();
         }
       }

--- a/frontend/components/main/friend_list/Friend.tsx
+++ b/frontend/components/main/friend_list/Friend.tsx
@@ -36,11 +36,7 @@ const Friend = ({ prop }: { prop: IFriend }) => {
             </Typography>
           </Tooltip>
           <Stack direction={"row"} alignItems={"center"}>
-            {prop.isOnline === IOnlineStatus.ONLINE
-              ? loginOn
-              : prop.isOnline === IOnlineStatus.OFFLINE
-              ? loginOff
-              : playing}
+            {prop.isOnline === IOnlineStatus.ONLINE ? loginOn : loginOff}
             <FriendProfile prop={prop as IFriend} />
           </Stack>
         </Stack>

--- a/frontend/components/main/friend_list/Friend.tsx
+++ b/frontend/components/main/friend_list/Friend.tsx
@@ -40,7 +40,7 @@ const Friend = ({ prop }: { prop: IFriend }) => {
               ? loginOn
               : prop.isOnline === IOnlineStatus.OFFLINE
               ? loginOff
-              : ""}
+              : playing}
             <FriendProfile prop={prop as IFriend} />
           </Stack>
         </Stack>

--- a/frontend/components/main/friend_list/FriendProfile.tsx
+++ b/frontend/components/main/friend_list/FriendProfile.tsx
@@ -66,7 +66,7 @@ const FriendProfile = ({ prop }: { prop: IFriend }) => {
   });
   const { roomState, roomDispatch } = useRoom();
   const { userState } = useUser();
-  const { friendState, friendDispatch } = useFriend();
+  const { friendDispatch } = useFriend();
   const { authState } = useAuth();
 
   const RankSrc =

--- a/frontend/components/public/Modals.tsx
+++ b/frontend/components/public/Modals.tsx
@@ -13,6 +13,7 @@ import { main } from "@/type/type";
 import { useRouter } from "next/navigation";
 import { useGame } from "@/context/GameContext";
 import { useAuth } from "@/context/AuthContext";
+import { ReturnMsgDto } from "@/type/RoomType";
 
 const modalStyle = {
   position: "absolute" as "absolute",
@@ -42,6 +43,7 @@ const Modals = ({
   const router = useRouter();
   const { gameState } = useGame();
   const { authState } = useAuth();
+
   return isShowing
     ? createPortal(
         <Modal open={isShowing} onClose={hide}>
@@ -100,6 +102,14 @@ const Modals = ({
                         gameState.aPlayer.id
                       );
                       authState.gameSocket!.disconnect();
+                      if (!authState.chatSocket) return;
+                      authState.chatSocket.emit(
+                        "BR_set_status_online",
+                        {
+                          userNickname: authState.userInfo.nickname,
+                        },
+                        (ret: ReturnMsgDto) => {}
+                      );
                       router.replace(routing);
                     }}
                   >

--- a/frontend/context/ModalContext.tsx
+++ b/frontend/context/ModalContext.tsx
@@ -1,7 +1,6 @@
 import { ReactNode, FC, useState, useContext } from "react";
 import { createContext } from "react";
 
-
 type ModalData = {
   children?: ReactNode;
   onCancel?: () => unknown;
@@ -16,8 +15,8 @@ const ModalContext = createContext<{
 }>({} as any);
 
 export const useModalContext = () => {
-  return useContext(ModalContext)
-}
+  return useContext(ModalContext);
+};
 
 export const ModalContextProvider: FC<{ children: ReactNode }> = ({
   children,

--- a/frontend/type/type.tsx
+++ b/frontend/type/type.tsx
@@ -144,3 +144,9 @@ export interface user_status {
   userIdx: number;
   isOnline: IOnlineStatus;
 }
+
+export interface IOnGame {
+  nickname: string;
+  userIdx: number;
+  isOnline: IOnlineStatus;
+}


### PR DESCRIPTION
- 노란색 불빛 보이게 하는거 x
- 그저 멤버, 친구 프로필에서 친선전 버튼 누를때, 메인화면에서 crazy pong 버튼 누를때 서버쪽으로 emit 보내서 백엔드에서 누른 사람의 상태 바뀌게 촉구
- 뒤로가기, 도망가기, 게임 중 새로고침, 친선전 초대 보냈는데 거절됐을때, 친선전 초대 받았을때 거절 눌렀을때, 결과 페이지에서 메인화면으로 돌아올때 등 ongame status를 online status로 바꾸는 api 적용
- 친구인 유저가 로그인안했을때 초록불 뜨는거 disconnect해서 빨간불 뜨게 함