### PR TITLE
234 should be unset

### DIFF
--- a/frontend/components/main/member_list/Member.tsx
+++ b/frontend/components/main/member_list/Member.tsx
@@ -68,12 +68,16 @@ export default function Member({
         ? setIsAdmin(true)
         : setIsAdmin(false);
     });
-  }, [roomState.adminAry]);
+  }, [roomState.adminAry, roomState.currentRoom]);
 
   const handleOpenMenu = (
     e: MouseEvent<HTMLDivElement, globalThis.MouseEvent>
   ) => {
     e.preventDefault();
+    let imAdmin = roomState.adminAry.find((admin) => {
+      return admin.nickname === person.nickname;
+    });
+    if (imAdmin !== undefined) setIsAuthorized(true);
     userState.nickname === roomState.currentRoom?.owner || isAdmin
       ? setAnchorEl(e.currentTarget)
       : null;

--- a/frontend/components/main/room_list/Room.tsx
+++ b/frontend/components/main/room_list/Room.tsx
@@ -58,12 +58,13 @@ export default function Room({ room, idx }: { room: IChatRoom; idx: number }) {
         };
       });
       const newRoom: IChatRoom = {
-        owner: owner ? owner : room.owner,
+        owner: owner,
         channelIdx: roomState.currentRoom!.channelIdx,
         mode: roomState.currentRoom!.mode,
       };
       roomDispatch({ type: "SET_CUR_MEM", value: list });
       roomDispatch({ type: "SET_CUR_ROOM", value: newRoom });
+      room.owner = owner;
     };
     authState.chatSocket.on("chat_room_exit", ChatExitRoom);
 


### PR DESCRIPTION
- 채널 오너가 나가면 채팅방 목록 채팅방제목 바로 안달라졌었는데, 이젠 바로바로 달라짐
- unset admin이 안뜨는 상황
A가 방장인 상태, B,C를 모두 admin으로 등록하고 방을 나감
2. A가 방을 나가서 B가 새로운 방장이 되었는데, B가 C를 보았을 때, unsetadmin이 나오지 않고, 같은 admin이라 kick,ban,mute 할 수 없다고 나옴.
+) 다시 방에 들어온 A는 set admin, mute, kick, ban 모두 됨.
고침
우클릭시 해당 멤버가 관리자 배열에 있는지 확인 후 있으면 setIsAuthorized(true) 해줌