### PR TITLE
[FIX] 친구, 멤버 프로필에서 draw 경기결과 0 : 0 표기 안되는 현상 고침, (내프로필은 표기됨)

### DIFF
--- a/frontend/components/main/friend_list/FriendGameLog.tsx
+++ b/frontend/components/main/friend_list/FriendGameLog.tsx
@@ -169,7 +169,7 @@ const FriendGameLog = ({ person }: { person: IFriend }) => {
                 >
                   <Typography sx={{ fontSize: "1.5rem" }}>
                     {/* 내닉네임 | 점수 : 점수 | 상대닉네임 */}
-                    {person.friendNickname} {gameRecordData.score}{" "}
+                    {person.friendNickname} {gameRecordData.score ? gameRecordData.score : "0 : 0"}{" "}
                     {gameRecordData.matchUserNickname}
                   </Typography>
                 </div>

--- a/frontend/components/main/member_list/MemberGameLog.tsx
+++ b/frontend/components/main/member_list/MemberGameLog.tsx
@@ -187,7 +187,7 @@ const MemberGameLog = ({
                 >
                   <Typography sx={{ fontSize: "1.5rem" }}>
                     {/* 내닉네임 | 점수 : 점수 | 상대닉네임 */}
-                    {person.nickname} {gameRecordData.score}{" "}
+                    {person.nickname} {gameRecordData.score ? gameRecordData.score : "0 : 0"}{" "}
                     {gameRecordData.matchUserNickname}
                   </Typography>
                 </div>


### PR DESCRIPTION
<img width="1503" alt="Screenshot 2023-09-21 at 10 31 39 PM" src="https://github.com/Gaepo-transcendance-fighters/FRONT-END/assets/87654307/c32d70b8-4e34-444e-b380-79e12902ec44">
