### PR TITLE
[FIX] 게임화면에서 창을 끄면 상대의 친구리스트에서는 빨간불로 갱신되지 않는다.

### DIFF
--- a/frontend/components/main/friend_list/Friend.tsx
+++ b/frontend/components/main/friend_list/Friend.tsx
@@ -36,7 +36,7 @@ const Friend = ({ prop }: { prop: IFriend }) => {
             </Typography>
           </Tooltip>
           <Stack direction={"row"} alignItems={"center"}>
-            {prop.isOnline === IOnlineStatus.ONLINE ? loginOn : loginOff}
+            {prop.isOnline === IOnlineStatus.ONLINE || prop.isOnline === IOnlineStatus.GAMEING ? loginOn : loginOff}
             <FriendProfile prop={prop as IFriend} />
           </Stack>
         </Stack>


### PR DESCRIPTION
### 해결
- 프론트 : online, offline, gaming 3가지의 상태중 online, gaming 일때 초록불로 띄워지게 변경.
- 백엔드 : 게임으로 넘어갈때 상태를 offline으로 변경하고 보내주던 코드 삭제. -> 백엔드도 pr 예정